### PR TITLE
Tidied test and optimised object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.10.2
+
+ - Reuse service definition objects via `_get_resource_definitions` to save on time spent reinstantiating identical objects
+ - Only instantiate the default `ServiceMapping` from `get_service_mapping` if it's required.
+ - Reduced number of regions tested from _all_ to 3.
+
 # 0.10.1
 
 - S3 buckets and other regional resources of global services will now only be written in their service's globalRegion

--- a/cloudwanderer/custom_resource_definitions.py
+++ b/cloudwanderer/custom_resource_definitions.py
@@ -153,3 +153,6 @@ class CustomResourceDefinitions():
     def _setup_boto3_loader(self) -> None:
         self._boto3_loader = self.botocore_session.get_component('data_loader')
         self._boto3_loader.search_paths.append(os.path.join(os.path.dirname(boto3.__file__), 'data'))
+
+
+DEFAULT_RESOURCE_DEFINITIONS = CustomResourceDefinitions()

--- a/cloudwanderer/service_mappings.py
+++ b/cloudwanderer/service_mappings.py
@@ -16,7 +16,7 @@ import boto3
 from botocore.client import ClientCreator
 import jmespath
 from boto3.resources.model import ResourceModel
-from .custom_resource_definitions import DEFAULT_RESOURCE_DEFINITIONS
+from .custom_resource_definitions import _get_resource_definitions
 
 
 class ServiceMappingCollection:
@@ -87,7 +87,7 @@ class ServiceMapping:
         self.service_name = service_name
         self.service_mapping = service_mapping
         self.boto3_client = self.boto3_session.client(service_name)
-        self.boto3_service_definition = DEFAULT_RESOURCE_DEFINITIONS.definitions[service_name]
+        self.boto3_service_definition = _get_resource_definitions().definitions[service_name]
 
     @property
     def global_service_region(self) -> bool:

--- a/cloudwanderer/service_mappings.py
+++ b/cloudwanderer/service_mappings.py
@@ -16,7 +16,7 @@ import boto3
 from botocore.client import ClientCreator
 import jmespath
 from boto3.resources.model import ResourceModel
-from .custom_resource_definitions import CustomResourceDefinitions
+from .custom_resource_definitions import DEFAULT_RESOURCE_DEFINITIONS
 
 
 class ServiceMappingCollection:
@@ -87,8 +87,7 @@ class ServiceMapping:
         self.service_name = service_name
         self.service_mapping = service_mapping
         self.boto3_client = self.boto3_session.client(service_name)
-        custom_resource_definitions = CustomResourceDefinitions()
-        self.boto3_service_definition = custom_resource_definitions.definitions[service_name]
+        self.boto3_service_definition = DEFAULT_RESOURCE_DEFINITIONS.definitions[service_name]
 
     @property
     def global_service_region(self) -> bool:

--- a/cloudwanderer/service_mappings.py
+++ b/cloudwanderer/service_mappings.py
@@ -39,12 +39,12 @@ class ServiceMappingCollection:
         """Returns the mapping for service_name."""
         if self._service_maps is None:
             self._service_maps = self.get_service_maps()
-        default_service_map = ServiceMapping(
+
+        return self._service_maps.get(service_name, ServiceMapping(
             service_name=service_name,
             service_mapping={},
             boto3_session=self.boto3_session,
-        )
-        return self._service_maps.get(service_name, default_service_map)
+        ))
 
     def get_service_maps(self) -> List['ServiceMapping']:
         """Return our custom resource definitions."""

--- a/doc_source/conf.py
+++ b/doc_source/conf.py
@@ -25,7 +25,7 @@ copyright = '2020, Sam Martin'
 author = 'Sam Martin'
 
 # The full version, including alpha/beta/rc tags
-release = '0.10.1'
+release = '0.10.2'
 
 nitpicky = True
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
     long_description = re.sub(r'..\s+doctest\s+::', '.. code-block ::', f.read())
 
 setup(
-    version='0.10.1',
+    version='0.10.2',
     python_requires='>=3.6.0',
     name='cloudwanderer',
     packages=find_packages(include=['cloudwanderer', 'cloudwanderer.*']),

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource_attributes.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource_attributes.py
@@ -24,13 +24,12 @@ class TestCloudWandererWriteResourceAttributes(unittest.TestCase, MockStorageCon
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        setup_moto(restrict_regions=ENABLED_REGIONS)
-        add_infra()
-        self.mock_storage_connector = MagicMock()
-        self.wanderer = CloudWanderer(
-            storage_connectors=[self.mock_storage_connector],
-            boto3_session=generate_mock_session()
+        self.enabled_regions = ['eu-west-2', 'us-east-1', 'ap-east-1']
+        setup_moto(
+            restrict_regions=self.enabled_regions,
         )
+        self.mock_session = generate_mock_session()
+        add_infra(regions=self.enabled_regions)
         self.expected_service_logs = expected_service_logs()
 
     def setUp(self):
@@ -43,7 +42,7 @@ class TestCloudWandererWriteResourceAttributes(unittest.TestCase, MockStorageCon
     def test_write_secondary_attributes(self):
         self.wanderer.write_secondary_attributes()
 
-        for region_name in ENABLED_REGIONS:
+        for region_name in self.enabled_regions:
             self.assert_storage_connector_write_secondary_attribute_called_with(
                 region=region_name,
                 service='ec2',

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource_attributes.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource_attributes.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
-from ..mocks import add_infra, generate_mock_session, ENABLED_REGIONS
+from ..mocks import add_infra, generate_mock_session
 from ..helpers import MockStorageConnectorMixin, setup_moto, get_secondary_attribute_types
 from cloudwanderer import CloudWanderer
 from cloudwanderer.boto3_interface import CloudWandererBoto3Interface

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import ANY
-from ..helpers import patch_resource_collections, patch_services, MockStorageConnectorMixin, mock_services, setup_moto
+from ..helpers import MockStorageConnectorMixin, setup_moto
 from ..mocks import (
     add_infra,
     MOCK_COLLECTION_INSTANCES,
@@ -8,7 +8,6 @@ from ..mocks import (
     MOCK_COLLECTION_IAM_GROUPS,
     MOCK_COLLECTION_IAM_ROLES,
     MOCK_COLLECTION_IAM_ROLE_POLICIES,
-    ENABLED_REGIONS,
     generate_mock_session
 )
 from cloudwanderer import CloudWanderer

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import ANY
-from ..helpers import patch_resource_collections, patch_services, MockStorageConnectorMixin, mock_services
+from ..helpers import patch_resource_collections, patch_services, MockStorageConnectorMixin, mock_services, setup_moto
 from ..mocks import (
     add_infra,
     MOCK_COLLECTION_INSTANCES,
@@ -19,10 +19,18 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        mock_services()
-        add_infra()
+        self.enabled_regions = ['eu-west-2', 'us-east-1', 'ap-east-1']
+        setup_moto(
+            restrict_regions=self.enabled_regions,
+            restrict_services=['ec2', 's3', 'iam'],
+            restrict_collections=[
+                MOCK_COLLECTION_INSTANCES, MOCK_COLLECTION_BUCKETS,
+                MOCK_COLLECTION_IAM_GROUPS, MOCK_COLLECTION_IAM_ROLES,
+                MOCK_COLLECTION_IAM_ROLE_POLICIES
+            ]
+        )
         self.mock_session = generate_mock_session()
-        self.enabled_regions = ENABLED_REGIONS
+        add_infra(regions=self.enabled_regions)
 
     def setUp(self):
         self.storage_connector = MemoryStorageConnector()
@@ -30,12 +38,7 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
             storage_connectors=[self.storage_connector],
             boto3_session=self.mock_session
         )
-        self.wanderer._enabled_regions = ENABLED_REGIONS
 
-    @patch_services(['ec2', 's3', 'iam'])
-    @patch_resource_collections(collections=[
-        MOCK_COLLECTION_INSTANCES, MOCK_COLLECTION_BUCKETS,
-        MOCK_COLLECTION_IAM_GROUPS, MOCK_COLLECTION_IAM_ROLES])
     def test_write_resources(self):
 
         self.wanderer.write_resources()
@@ -81,10 +84,6 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
                     }
                 )
 
-    @patch_services(['ec2', 's3', 'iam'])
-    @patch_resource_collections(collections=[
-        MOCK_COLLECTION_INSTANCES, MOCK_COLLECTION_BUCKETS,
-        MOCK_COLLECTION_IAM_GROUPS])
     def test_write_resources_in_region_default_region(self):
 
         self.wanderer.write_resources_in_region()
@@ -117,11 +116,6 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
             }
         )
 
-    @patch_services(['ec2', 's3', 'iam'])
-    @patch_resource_collections(collections=[
-        MOCK_COLLECTION_INSTANCES, MOCK_COLLECTION_BUCKETS,
-        MOCK_COLLECTION_IAM_GROUPS, MOCK_COLLECTION_IAM_ROLES,
-        MOCK_COLLECTION_IAM_ROLE_POLICIES])
     def test_write_resources_in_region_specify_region(self):
         self.wanderer.write_resources_in_region(region_name='us-east-1')
 
@@ -171,9 +165,6 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
             }
         )
 
-    @patch_resource_collections(collections=[
-        MOCK_COLLECTION_INSTANCES, MOCK_COLLECTION_BUCKETS,
-        MOCK_COLLECTION_IAM_GROUPS])
     def test_write_resources_of_service_default_region(self):
         self.wanderer.write_resources_of_service_in_region(service_name='ec2')
         self.wanderer.write_resources_of_service_in_region(service_name='s3')
@@ -206,9 +197,6 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
             }
         )
 
-    @patch_resource_collections(collections=[
-        MOCK_COLLECTION_INSTANCES, MOCK_COLLECTION_BUCKETS,
-        MOCK_COLLECTION_IAM_GROUPS])
     def test_write_resources_of_service_specify_region(self):
         self.wanderer.write_resources_of_service_in_region(service_name='ec2', region_name='us-east-1')
         self.wanderer.write_resources_of_service_in_region(service_name='s3', region_name='us-east-1')
@@ -275,7 +263,6 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
             }
         )
 
-    @patch_services(['iam'])
     def test_write_resources_of_type_in_region_specify_region(self):
         self.wanderer.write_resources_of_type_in_region(
             service_name='s3', resource_type='bucket', region_name='us-east-1')

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -12,6 +12,7 @@ import boto3
 DEFAULT_SESSION = boto3.Session()
 logger = logging.getLogger(__file__)
 
+
 def filter_collections(collections, service_resource):
     for collection in collections:
         if service_resource.meta.resource_model.name == collection.meta.service_name:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from unittest.mock import patch, MagicMock
 import functools
 from botocore import xform_name
@@ -9,7 +10,7 @@ from moto import ec2, mock_ec2, mock_iam, mock_sts, mock_s3, mock_dynamodb2
 import boto3
 
 DEFAULT_SESSION = boto3.Session()
-
+logger = logging.getLogger(__file__)
 
 def filter_collections(collections, service_resource):
     for collection in collections:
@@ -151,21 +152,23 @@ class TestStorageConnectorReadMixin:
             )
 
 
-def limit_collections_list():
+def limit_collections_list(restrict_collections):
     """Limit the boto3 resource collections we service to a subset we use for testing."""
-    collections_to_mock = [
-        ('ec2', ('instance', 'instances')),
-        ('ec2', ('vpc', 'vpcs')),
-        ('s3', ('bucket', 'buckets')),
-        ('iam', ('group', 'groups')),
-        ('iam', ('Role', 'roles')),
-        ('Role', ('RolePolicy', 'policies'))
-    ]
-    mock_collections = []
-    for service, name_tuple in collections_to_mock:
-        mock_collections.append(generate_mock_collection(service, name_tuple[0], name_tuple[1]))
+    if not restrict_collections:
+        collections_to_mock = [
+            ('ec2', ('instance', 'instances')),
+            ('ec2', ('vpc', 'vpcs')),
+            ('s3', ('bucket', 'buckets')),
+            ('iam', ('group', 'groups')),
+            ('iam', ('Role', 'roles')),
+            ('Role', ('RolePolicy', 'policies'))
+        ]
+        restrict_collections = []
+        for service, name_tuple in collections_to_mock:
+            restrict_collections.append(generate_mock_collection(service, name_tuple[0], name_tuple[1]))
+    logger.debug('Mocking collections: %s', restrict_collections)
     cloudwanderer.cloud_wanderer.CloudWandererBoto3Interface.get_resource_collections = MagicMock(
-        side_effect=lambda boto3_service: filter_collections(mock_collections, boto3_service)
+        side_effect=lambda boto3_service: filter_collections(restrict_collections, boto3_service)
     )
 
 
@@ -175,7 +178,8 @@ def mock_services():
         mock.start()
 
 
-def setup_moto(restrict_regions: list = None, restrict_services: bool = True, restrict_collections: bool = True):
+def setup_moto(restrict_regions: list = None, restrict_services: bool = True,
+               restrict_collections: list = None):
     os.environ['AWS_ACCESS_KEY_ID'] = '1111111'
     os.environ['AWS_SECRET_ACCESS_KEY'] = '1111111'
     os.environ['AWS_SESSION_TOKEN'] = '1111111'
@@ -189,8 +193,8 @@ def setup_moto(restrict_regions: list = None, restrict_services: bool = True, re
     if restrict_services:
         cloudwanderer.cloud_wanderer.CloudWandererBoto3Interface.get_all_resource_services = MagicMock(
             return_value=[boto3.resource(service) for service in ['ec2', 's3', 'iam']])
-    if restrict_collections:
-        limit_collections_list()
+    if restrict_collections is not False:
+        limit_collections_list(restrict_collections)
     mock_services()
 
 

--- a/tests/integration/mocks.py
+++ b/tests/integration/mocks.py
@@ -57,7 +57,7 @@ def generate_mock_session(region='eu-west-2'):
     )
 
 
-def add_infra(count=1, regions=ENABLED_REGIONS):
+def add_infra(count=1, regions=['us-east-1', 'eu-west-1', 'ap-east-1']):
     os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
     os.environ['AWS_SECURITY_TOKEN'] = 'testing'


### PR DESCRIPTION
 - Reuse service definition objects via `_get_resource_definitions` to save on time spent reinstantiating identical objects
 - Only instantiate the default `ServiceMapping` from `get_service_mapping` if it's required.
 - Reduced number of regions tested from _all_ to 3.