### PR TITLE
Feature/swap subresource id seperator to slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     cleaning up resources in that region. E.g. it would write buckets from all regions from `us-east-1`
     and then _only_ cleanup `us-east-1` s3 buckets.
 - Removed `client_args` as an explicit argument on cloudwanderer resources, any keywords args supplied to `write_` methods are now passed into the `get_` methods of the `cloud_interface`
+- Subresources now build their compound id using a `/` separator rather than a `:` separator. This ensures that
+    `:` remains the primary separator for URN parts.
 
 # 0.10.2
 

--- a/cloudwanderer/aws_urn.py
+++ b/cloudwanderer/aws_urn.py
@@ -56,7 +56,7 @@ class AwsUrn():
             region=parts[3],
             service=parts[4],
             resource_type=parts[5],
-            resource_id=':'.join(parts[6:])
+            resource_id=parts[6]
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/cloudwanderer/boto3_interface.py
+++ b/cloudwanderer/boto3_interface.py
@@ -293,7 +293,7 @@ class CloudWandererBoto3Interface:
             if id_part.startswith('arn:'):
                 id_part = ''.join(id_part.split(':')[5:])
             resource_ids.append(id_part)
-        compound_resource_id = ':'.join(resource_ids)
+        compound_resource_id = '/'.join(resource_ids)
         service_map = self.service_maps.get_service_mapping(resource.meta.service_name)
         return AwsUrn(
             account_id=self.account_id,

--- a/doc_source/examples.rst
+++ b/doc_source/examples.rst
@@ -136,7 +136,7 @@ Then we can lookup the inline policy
     ...     region=role.urn.region,
     ...     service='iam',
     ...     resource_type='role_policy',
-    ...     resource_id=f"{role.urn.resource_id}:test-role-policy"
+    ...     resource_id=f"{role.urn.resource_id}/test-role-policy"
     ... )
     >>> inline_policy = storage_connector.read_resource(urn=inline_policy_urn)
     >>> inline_policy.policy_document

--- a/tests/unit/test_aws_urn.py
+++ b/tests/unit/test_aws_urn.py
@@ -10,15 +10,20 @@ class TestAwsUrn(unittest.TestCase):
             region='us-east-1',
             service='ec2',
             resource_type='role_policy',
-            resource_id='test-role:test-policy'
+            resource_id='test-role/test-policy'
         )
 
     def test_from_string(self):
         assert AwsUrn.from_string(
-            'urn:aws:111111111111:us-east-1:ec2:role_policy:test-role:test-policy') == self.test_urn
+            'urn:aws:111111111111:us-east-1:ec2:role_policy:test-role/test-policy') == self.test_urn
+
+    def test_from_string_with_nonstandard_extra_parts(self):
+        assert AwsUrn.from_string(
+            'urn:aws:111111111111:us-east-1:ec2:'
+            'role_policy:test-role/test-policy:this:should:not:be:included') == self.test_urn
 
     def test_str(self):
-        assert str(self.test_urn) == 'urn:aws:111111111111:us-east-1:ec2:role_policy:test-role:test-policy'
+        assert str(self.test_urn) == 'urn:aws:111111111111:us-east-1:ec2:role_policy:test-role/test-policy'
 
     def test_repr(self):
         assert repr(self.test_urn) == str(
@@ -27,5 +32,5 @@ class TestAwsUrn(unittest.TestCase):
             "region='us-east-1', "
             "service='ec2', "
             "resource_type='role_policy', "
-            "resource_id='test-role:test-policy')"
+            "resource_id='test-role/test-policy')"
         )


### PR DESCRIPTION
Subresources now build their compound id using a `/` separator rather than a `:` separator. This ensures that
    `:` remains the primary separator for URN parts.