### PR TITLE
Formalise CloudInterface return values #74

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: master
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 5.1.1
+    hooks:
+      - id: pydocstyle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.12.0
+
+- Formalised the interface between the `CloudInterface` > `CloudWanderer` > `StorageConnector` by
+    converting Boto3 resources to `CloudWandererResources`
+    - Removed `write_secondary_attributes` from `BaseStorageConnector` as it's no longer required to be public.
+
 # 0.11.0
 
 - Collapsed all `write_secondary_attributes` methods into `write_resources` so secondary attributes are written automatically.

--- a/cloudwanderer/boto3_interface.py
+++ b/cloudwanderer/boto3_interface.py
@@ -5,8 +5,8 @@ Provides simpler methods for :class:`~.cloud_wanderer.CloudWanderer` to call.
 from typing import List, Iterator
 import logging
 import boto3
+import botocore
 from botocore import xform_name
-from botocore.exceptions import EndpointConnectionError, ClientError
 from boto3.resources.base import ServiceResource
 from boto3.resources.model import Collection, ResourceModel
 from .cloud_wanderer_resource import CloudWandererResource, SecondaryAttribute
@@ -87,16 +87,16 @@ class CloudWandererBoto3Interface:
             boto3_resource_collection (boto3.resources.model.Collection): The resource collection to get.
 
         Raises:
-            ClientError: A Boto3 client error.
+            botocore.exceptions.ClientError: A Boto3 client error.
         """
         if not hasattr(boto3_service, boto3_resource_collection.name):
             logger.warning('%s does not have %s', boto3_service.__class__.__name__, boto3_resource_collection.name)
             return
         try:
             yield from getattr(boto3_service, boto3_resource_collection.name).all()
-        except EndpointConnectionError as ex:
+        except botocore.exceptions.EndpointConnectionError as ex:
             logger.warning(ex)
-        except ClientError as ex:
+        except botocore.exceptions.ClientError as ex:
             if ex.response['Error']['Code'] == 'InvalidAction':
                 logger.warning(ex.response['Error']['Message'])
                 return

--- a/cloudwanderer/boto3_interface.py
+++ b/cloudwanderer/boto3_interface.py
@@ -182,9 +182,7 @@ class CloudWandererBoto3Interface:
             boto3_resource (boto3.resources.base.ServiceResource): The :class:`boto3.resources.base.ServiceResource`
                 to get secondary attributes from
         """
-        for subresource in self.get_child_resources(boto3_resource=boto3_resource, resource_type='resource'):
-            subresource.load()
-            yield subresource
+        yield from self.get_child_resources(boto3_resource=boto3_resource, resource_type='resource')
 
     def get_secondary_attributes(self, boto3_resource: boto3.resources.base.ServiceResource) -> SecondaryAttribute:
         """Return all secondary attributes resources for this resource.
@@ -236,10 +234,13 @@ class CloudWandererBoto3Interface:
                 continue
             if resource_mapping.resource_type != resource_type:
                 continue
-            yield from self.get_resource_from_collection(
+            child_resources = self.get_resource_from_collection(
                 boto3_service=boto3_resource,
                 boto3_resource_collection=child_resource_collection
             )
+            for resource in child_resources:
+                resource.load()
+                yield resource
 
     def get_child_resource_definitions(
             self, service_name: str, boto3_resource_model: boto3.resources.model.ResourceModel,

--- a/cloudwanderer/cloud_wanderer.py
+++ b/cloudwanderer/cloud_wanderer.py
@@ -181,15 +181,6 @@ class CloudWanderer():
         for storage_connector in self.storage_connectors:
             storage_connector.write_resource(urn, boto3_resource)
         yield urn
-        yield from self._write_subresources(boto3_resource, region_name)
-
-    def _write_subresources(self, boto3_resource: ServiceResource, region_name: str) -> Iterator[AwsUrn]:
-        for subresource in self.cloud_interface.get_subresources(boto3_resource=boto3_resource):
-            subresource.load()
-            urn = self.cloud_interface._get_resource_urn(subresource, region_name)
-            yield urn
-            for storage_connector in self.storage_connectors:
-                storage_connector.write_resource(urn, subresource)
 
     def _write_secondary_attributes(self, boto3_resource: ServiceResource, region_name: str) -> Iterator[AwsUrn]:
         secondary_attributes = self.cloud_interface.get_secondary_attributes(

--- a/cloudwanderer/cloud_wanderer.py
+++ b/cloudwanderer/cloud_wanderer.py
@@ -4,8 +4,6 @@ from typing import List
 import logging
 from typing import TYPE_CHECKING, Iterator, Callable
 import concurrent.futures
-from boto3.resources.base import ServiceResource
-from botocore import xform_name
 from .utils import exception_logging_wrapper
 from .boto3_interface import CloudWandererBoto3Interface
 from .aws_urn import AwsUrn

--- a/cloudwanderer/cloud_wanderer.py
+++ b/cloudwanderer/cloud_wanderer.py
@@ -1,4 +1,5 @@
 """Main cloudwanderer module."""
+from cloudwanderer.cloud_wanderer_resource import CloudWandererResource
 from typing import List
 import logging
 from typing import TYPE_CHECKING, Iterator, Callable
@@ -170,32 +171,15 @@ class CloudWanderer():
         resources = self.cloud_interface.get_resources_of_type(
             service_name=service_name, resource_type=resource_type, region_name=region_name, **kwargs)
         urns = []
-        for boto3_resource in resources:
-            urns.extend(list(self._write_resource(boto3_resource, region_name)))
-            urns.extend(list(self._write_secondary_attributes(boto3_resource, region_name)))
+        for resource in resources:
+            urns.extend(list(self._write_resource(resource, region_name)))
 
         self._clean_resources_in_region(service_name, resource_type, region_name, urns)
 
-    def _write_resource(self, boto3_resource: ServiceResource, region_name: str) -> Iterator[AwsUrn]:
-        urn = self.cloud_interface._get_resource_urn(boto3_resource, region_name)
+    def _write_resource(self, resource: CloudWandererResource, region_name: str) -> Iterator[AwsUrn]:
         for storage_connector in self.storage_connectors:
-            storage_connector.write_resource(urn, boto3_resource)
-        yield urn
-
-    def _write_secondary_attributes(self, boto3_resource: ServiceResource, region_name: str) -> Iterator[AwsUrn]:
-        secondary_attributes = self.cloud_interface.get_secondary_attributes(
-            boto3_resource=boto3_resource)
-        for secondary_attribute in secondary_attributes:
-            attribute_type = xform_name(secondary_attribute.meta.resource_model.name)
-            logger.info('---> Fetching %s in %s', attribute_type, region_name)
-            urn = self.cloud_interface._get_resource_urn(boto3_resource, region_name)
-            for storage_connector in self.storage_connectors:
-                storage_connector.write_secondary_attribute(
-                    urn=urn,
-                    secondary_attribute=secondary_attribute,
-                    attribute_type=attribute_type
-                )
-            yield urn
+            storage_connector.write_resource(resource)
+        yield resource.urn
 
     def _clean_resources_in_region(
             self, service_name: str, resource_type: str, region_name: str, current_urns: List[AwsUrn]) -> None:

--- a/cloudwanderer/cloud_wanderer_resource.py
+++ b/cloudwanderer/cloud_wanderer_resource.py
@@ -50,7 +50,7 @@ class CloudWandererResource():
         """
         self.urn = urn
         self.cloudwanderer_metadata = ResourceMetadata(
-            resource_data=resource_data,
+            resource_data=resource_data or {},
             secondary_attributes=secondary_attributes or []
         )
         self._loader = loader

--- a/cloudwanderer/cloud_wanderer_resource.py
+++ b/cloudwanderer/cloud_wanderer_resource.py
@@ -116,7 +116,7 @@ class SecondaryAttribute(dict):
     attribute_name attribute.
     """
 
-    def __init__(self, attribute_name: str, **kwargs):
+    def __init__(self, attribute_name: str, **kwargs) -> None:
         """Initialise the Secondary Attribute
 
         Arguments:

--- a/cloudwanderer/cloud_wanderer_resource.py
+++ b/cloudwanderer/cloud_wanderer_resource.py
@@ -117,12 +117,11 @@ class SecondaryAttribute(dict):
     """
 
     def __init__(self, attribute_name: str, **kwargs) -> None:
-        """Initialise the Secondary Attribute
+        """Initialise the Secondary Attribute.
 
         Arguments:
             attribute_name (str): The name of the attribute
             **kwargs: The attributes keys and values
         """
-
         super().__init__(**kwargs)
         self.attribute_name = attribute_name

--- a/cloudwanderer/cloud_wanderer_resource.py
+++ b/cloudwanderer/cloud_wanderer_resource.py
@@ -107,3 +107,22 @@ class CloudWandererResource():
     def __str__(self) -> str:
         """Return the string representation of this Resource."""
         return repr(self)
+
+
+class SecondaryAttribute(dict):
+    """Partially formalised SecondaryAttribute for resources.
+
+    Allows us to store unstructured data in a dict-like object while maintaining the
+    attribute_name attribute.
+    """
+
+    def __init__(self, attribute_name: str, **kwargs):
+        """Initialise the Secondary Attribute
+
+        Arguments:
+            attribute_name (str): The name of the attribute
+            **kwargs: The attributes keys and values
+        """
+
+        super().__init__(**kwargs)
+        self.attribute_name = attribute_name

--- a/cloudwanderer/storage_connectors/base_connector.py
+++ b/cloudwanderer/storage_connectors/base_connector.py
@@ -14,12 +14,11 @@ class BaseStorageConnector(ABC):
         """Initialise the storage backend whatever it is."""
 
     @abstractmethod
-    def write_resource(self, urn: AwsUrn, resource: boto3.resources.model.ResourceModel) -> None:
+    def write_resource(self, resource: CloudWandererResource) -> None:
         """Persist a single resource to storage.
 
         Arguments:
-            urn (AwsUrn): The URN of the resource to write.
-            resource (boto3.resources.model.ResourceModel): The boto3 resource to write.
+            resource (CloudWandererResource): The CloudWandererResource to write.
         """
 
     @abstractmethod
@@ -73,15 +72,4 @@ class BaseStorageConnector(ABC):
             service (str): Service name (e.g. ``'ec2'``)
             resource_type (str): Resource Type (e.g. ``'instance'``)
             urns_to_keep (List[cloudwanderer.aws_urn.AwsUrn]): A list of resources not to delete
-        """
-    @abstractmethod
-    def write_secondary_attribute(
-            self, urn: AwsUrn, attribute_type: str, secondary_attribute: boto3.resources.base.ServiceResource) -> None:
-        """Write the specified resource attribute to storage.
-
-        Arguments:
-            urn (AwsUrn): The resource whose attribute to write.
-            attribute_type (str): The type of the resource attribute to write (usually the boto3 client method name)
-            secondary_attribute (boto3.resources.base.ServiceResource): The resource attribute to write to storage.
-
         """

--- a/cloudwanderer/storage_connectors/base_connector.py
+++ b/cloudwanderer/storage_connectors/base_connector.py
@@ -1,7 +1,6 @@
 """Module containing abstract classes for CloudWanderer storage connectors."""
 from abc import ABC, abstractmethod
 from typing import List, Iterator
-import boto3
 from ..aws_urn import AwsUrn
 from ..cloud_wanderer_resource import CloudWandererResource
 

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -329,13 +329,17 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
         )
 
     def assert_resource_exists(self, *args, **kwargs):
-        result = self.resource_exists(*args, **kwargs)
-        assert len(result) > 0
-        assert all(x[0] for x in result)
+        results, resources = self.resource_exists(*args, **kwargs)
+        assert len(results) > 0
+        for comparison in results:
+            self.assertTrue(
+                comparison[0],
+                f"{comparison[2]} was not found at '{comparison[1]}' in any of {resources}"
+            )
 
     def assert_resource_not_exists(self, *args, **kwargs):
-        result = self.resource_exists(*args, **kwargs)
-        assert all(x[0] for x in result)
+        results, resources = self.resource_exists(*args, **kwargs)
+        assert all(x[0] for x in results)
 
     def resource_exists(self, region, service, resource_type, attributes_dict, secondary_attributes_dict=None):
         secondary_attributes_dict = secondary_attributes_dict or {}
@@ -362,4 +366,4 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
                     jmes_path,
                     value
                 ))
-        return matches
+        return matches, resources

--- a/tests/integration/mocks.py
+++ b/tests/integration/mocks.py
@@ -1,6 +1,6 @@
 import os
 import json
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 import boto3
 from cloudwanderer import AwsUrn
 
@@ -97,12 +97,4 @@ def generate_urn(service, resource_type, id):
         service=service,
         resource_type=resource_type,
         resource_id=id
-    )
-
-
-def generate_mock_secondary_attribute(data):
-    return Mock(
-        **{
-            'meta.data': data
-        }
     )

--- a/tests/integration/secondary_attributes/test_secondary_attributes.py
+++ b/tests/integration/secondary_attributes/test_secondary_attributes.py
@@ -1,6 +1,5 @@
 import unittest
 import boto3
-from botocore import xform_name
 from parameterized import parameterized
 from cloudwanderer.boto3_interface import CloudWandererBoto3Interface
 from ..mocks import add_infra
@@ -45,11 +44,9 @@ class TestSecondaryAttributes(unittest.TestCase):
             resource_type=resource_type
         )
         for resource in resources:
-            secondary_attributes = boto3_interface.get_secondary_attributes(
-                boto3_resource=resource)
-            for secondary_attribute in secondary_attributes:
-                if attribute_name == xform_name(secondary_attribute.meta.resource_model.name):
+            for secondary_attribute in resource.cloudwanderer_metadata.secondary_attributes:
+                if attribute_name == secondary_attribute.attribute_name:
                     results.append(secondary_attribute)
 
         assert len(results) > 0
-        assert results[-1].meta.data
+        assert dict(results[-1]) != {}

--- a/tests/integration/storage_write_generic.py
+++ b/tests/integration/storage_write_generic.py
@@ -1,5 +1,6 @@
-from .mocks import generate_mock_session, add_infra, generate_urn, generate_mock_secondary_attribute
+from .mocks import generate_mock_session, add_infra, generate_urn
 from .helpers import get_default_mocker
+from cloudwanderer.cloud_wanderer_resource import CloudWandererResource, SecondaryAttribute
 
 
 class StorageWriteTestMixin:
@@ -13,52 +14,58 @@ class StorageWriteTestMixin:
         cls.mock_session = generate_mock_session()
 
         add_infra(count=100, regions=['eu-west-2'])
-        cls.ec2_instances = list(cls.mock_session.resource('ec2').instances.all())
-        cls.vpcs = list(cls.mock_session.resource('ec2').vpcs.all())
+        cls.ec2_instances = [
+            CloudWandererResource(
+                urn=generate_urn(service='ec2', resource_type='instance', id=instance.instance_id),
+                resource_data=instance.meta.data
+            )
+            for instance in cls.mock_session.resource('ec2').instances.all()
+        ]
+        cls.vpcs = [
+            CloudWandererResource(
+                urn=generate_urn(service='ec2', resource_type='vpc', id=vpc.vpc_id),
+                resource_data=vpc.meta.data,
+                secondary_attributes=[
+                    SecondaryAttribute(
+                        attribute_name='EnableDnsSupport',
+                        **{'EnableDnsSupport': {'Value': True}}
+                    )
+                ]
+            )
+            for vpc in cls.mock_session.resource('ec2').vpcs.all()
+        ]
 
     @classmethod
     def tearDownClass(cls):
         get_default_mocker().stop_general_mock()
 
     def test_write_resource_and_attribute(self):
-        urn = generate_urn(service='ec2', resource_type='instance', id=self.ec2_instances[0].instance_id)
 
         self.connector.write_resource(
-            urn=urn,
-            resource=self.ec2_instances[0]
+            resource=self.vpcs[0]
         )
-        self.connector.write_secondary_attribute(
-            urn=urn,
-            attribute_type='vpc_enable_dns_support',
-            secondary_attribute=generate_mock_secondary_attribute({'EnableDnsSupport': {'Value': True}})
-        )
-        result = self.connector.read_resource(urn=urn)
-        assert result.urn == urn
-        assert result.instance_type == 'm1.small'
-        assert result.placement == {'AvailabilityZone': 'eu-west-2a', 'GroupName': None, 'Tenancy': 'default'}
+        result = self.connector.read_resource(urn=self.vpcs[0].urn)
+        assert result.urn == self.vpcs[0].urn
+        assert result.is_default is True
         assert result.cloudwanderer_metadata.secondary_attributes[0][
             'EnableDnsSupport'] == {
             'Value': True
         }
 
     def test_write_and_delete(self):
-        urn = generate_urn(service='ec2', resource_type='instance', id=self.ec2_instances[0].instance_id)
-
         self.connector.write_resource(
-            urn=urn,
             resource=self.ec2_instances[0]
         )
-        result_before_delete = self.connector.read_resource(urn=urn)
-        self.connector.delete_resource(urn=urn)
-        result_after_delete = self.connector.read_resource(urn=urn)
+        result_before_delete = self.connector.read_resource(urn=self.ec2_instances[0].urn)
+        self.connector.delete_resource(urn=self.ec2_instances[0].urn)
+        result_after_delete = self.connector.read_resource(urn=self.ec2_instances[0].urn)
 
-        assert result_before_delete.urn == urn
+        assert result_before_delete.urn == self.ec2_instances[0].urn
         assert result_after_delete is None
 
     def test_write_and_delete_resource_of_type_in_account_region(self):
         for i in range(5):
             self.connector.write_resource(
-                urn=generate_urn(service='ec2', resource_type='instance', id=self.ec2_instances[i].instance_id),
                 resource=self.ec2_instances[i]
             )
 

--- a/tests/unit/test_cloudwanderer_resource.py
+++ b/tests/unit/test_cloudwanderer_resource.py
@@ -101,3 +101,10 @@ class TestCloudWandererResource(unittest.TestCase):
             "resource_data={'CidrBlock': '10.0.0.0/0'}, secondary_attributes=[{'EnableDnsSupport': {'Value': True}}]"
             ")"
         )
+
+    def test_empty_instantiatio(self):
+        CloudWandererResource(
+            urn=AwsUrn.from_string('urn:aws:111111111111:eu-west-2:ec2:vpc:vpc-11111111'),
+            resource_data=None,
+            secondary_attributes=[]
+        )

--- a/tests/unit/test_cloudwanderer_resource.py
+++ b/tests/unit/test_cloudwanderer_resource.py
@@ -102,7 +102,12 @@ class TestCloudWandererResource(unittest.TestCase):
             ")"
         )
 
-    def test_empty_instantiatio(self):
+    def test_empty(self):
+        """Do not throw when there is no resource data.
+
+        This scenario occurs for some older AWS resources like sns topics as
+        their ``describe_`` methods can return no data.
+        """
         CloudWandererResource(
             urn=AwsUrn.from_string('urn:aws:111111111111:eu-west-2:ec2:vpc:vpc-11111111'),
             resource_data=None,

--- a/tests/unit/test_secondary_attributes.py
+++ b/tests/unit/test_secondary_attributes.py
@@ -1,0 +1,21 @@
+import unittest
+from cloudwanderer.cloud_wanderer_resource import SecondaryAttribute
+
+class TestSecondaryAttribute(unittest.TestCase):
+
+    def test_vpc_secondary_attribute(self):
+        secondary_attribute = SecondaryAttribute(
+            attribute_name='EnableDnsSupport',
+            **{'EnableDnsSupport': {'Value': True}}
+        )
+
+        assert secondary_attribute.attribute_name == 'EnableDnsSupport'
+        assert dict(secondary_attribute) == {'EnableDnsSupport': {'Value': True}}
+
+    def test_empty(self):
+        secondary_attribute = SecondaryAttribute(
+            attribute_name=None
+        )
+
+        assert secondary_attribute.attribute_name == None
+        assert dict(secondary_attribute) == {}

--- a/tests/unit/test_secondary_attributes.py
+++ b/tests/unit/test_secondary_attributes.py
@@ -1,6 +1,7 @@
 import unittest
 from cloudwanderer.cloud_wanderer_resource import SecondaryAttribute
 
+
 class TestSecondaryAttribute(unittest.TestCase):
 
     def test_vpc_secondary_attribute(self):
@@ -17,5 +18,5 @@ class TestSecondaryAttribute(unittest.TestCase):
             attribute_name=None
         )
 
-        assert secondary_attribute.attribute_name == None
+        assert secondary_attribute.attribute_name is None
         assert dict(secondary_attribute) == {}


### PR DESCRIPTION
- Formalised the interface between the `CloudInterface` > `CloudWanderer` > `StorageConnector` by
    converting Boto3 resources to `CloudWandererResources`
    - Removed `write_secondary_attributes` from `BaseStorageConnector` as it's no longer required to be public.