### PR TITLE
Clean response metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,4 @@ repos:
     rev: 5.1.1
     hooks:
       - id: pydocstyle
+        exclude: ^(tests|doc_source).*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,9 @@ repos:
     rev: master
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-annotations
+          - darglint
   - repo: https://github.com/pycqa/pydocstyle
     rev: 5.1.1
     hooks:

--- a/cloudwanderer/boto3_interface.py
+++ b/cloudwanderer/boto3_interface.py
@@ -345,8 +345,13 @@ class CloudWandererBoto3Interface:
         else:
             yield from self.enabled_regions
 
-    def _clean_boto3_metadata(self, boto3_metadata):
-        """Remove unwanted keys from boto3 metadata dictionaries."""
+    def _clean_boto3_metadata(self, boto3_metadata: dict) -> dict:
+        """Remove unwanted keys from boto3 metadata dictionaries.
+
+        Arguments:
+            boto3_metadata (dict): The raw dictionary of metadata typically found in resource.meta.data
+        """
+        boto3_metadata = boto3_metadata or {}
         unwanted_keys = ['ResponseMetadata']
         for key in unwanted_keys:
             if key in boto3_metadata:

--- a/cloudwanderer/boto3_interface.py
+++ b/cloudwanderer/boto3_interface.py
@@ -127,13 +127,13 @@ class CloudWandererBoto3Interface:
         for resource in resources:
             yield CloudWandererResource(
                 urn=self._get_resource_urn(resource, region_name),
-                resource_data=resource.meta.data,
+                resource_data=self._clean_boto3_metadata(resource.meta.data),
                 secondary_attributes=self.get_secondary_attributes(resource),
             )
             for subresource in self.get_subresources(resource):
                 yield CloudWandererResource(
                     urn=self._get_resource_urn(subresource, region_name),
-                    resource_data=subresource.meta.data,
+                    resource_data=self._clean_boto3_metadata(subresource.meta.data),
                     secondary_attributes=self.get_secondary_attributes(subresource),
                 )
 
@@ -199,7 +199,7 @@ class CloudWandererBoto3Interface:
         for secondary_attribute in secondary_attributes:
             yield SecondaryAttribute(
                 attribute_name=xform_name(secondary_attribute.meta.resource_model.name),
-                **secondary_attribute.meta.data)
+                **self._clean_boto3_metadata(secondary_attribute.meta.data))
 
     def get_child_resources(
             self, boto3_resource: boto3.resources.base.ServiceResource,
@@ -344,3 +344,11 @@ class CloudWandererBoto3Interface:
             yield region_name
         else:
             yield from self.enabled_regions
+
+    def _clean_boto3_metadata(self, boto3_metadata):
+        """Remove unwanted keys from boto3 metadata dictionaries."""
+        unwanted_keys = ['ResponseMetadata']
+        for key in unwanted_keys:
+            if key in boto3_metadata:
+                del boto3_metadata[key]
+        return boto3_metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flake8-annotations
 sphinx
 sphinx_rtd_theme
 darglint
+pre-commit

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -352,6 +352,8 @@ class TestCloudWandererWriteResources(unittest.TestCase, MockStorageConnectorMix
         matches = []
         for resource in resources:
             resource.load()
+            # No resource should have the ResponseMetadata attribute recorded.
+            self.assertRaises(AttributeError, getattr, resource, 'response_metadata')
             for attribute, value in attributes_dict.items():
                 result = False
                 try:


### PR DESCRIPTION
Prior to this change the `ResponseMetadata` key was being included in Resources.

```
"ResponseMetadata": {
    "HTTPHeaders": {
      "date": "Sun, 24 Jan 2021 13:47:04 GMT",
      "content-length": "715",
      "content-type": "text/xml",
      "x-amzn-requestid": "ea769012-9735-40a5-a8f2-3cde7fc20380"
    },
    "RequestId": "ea769012-9735-40a5-a8f2-3cde7fc20380",
    "HTTPStatusCode": 200,
    "RetryAttempts": 0
  }
``` 
which is not useful information for us to store.