### PR TITLE
Allow differentiation between CFN stacks and opsworks stacks #70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.12.0
 
+- Changed the way `exclude_resources` works so you can differentiate between CloudFormation Stacks and OpsWorks Stacks #70
 - Formalised the interface between the `CloudInterface` > `CloudWanderer` > `StorageConnector` by
     converting Boto3 resources to `CloudWandererResources`
     - Removed `write_secondary_attributes` from `BaseStorageConnector` as it's no longer required to be public.

--- a/cloudwanderer/cloud_wanderer.py
+++ b/cloudwanderer/cloud_wanderer.py
@@ -39,7 +39,7 @@ class CloudWanderer():
         Any additional args will be passed into the cloud interface's ``get_`` methods.
 
         Arguments:
-            exclude_resources (list): A list of resource names to exclude (e.g. ``['instance']``)
+            exclude_resources (list): A list of service:resources to exclude (e.g. ``['ec2:instance']``)
             **kwargs: Additional keyword argumentss will be passed down to the cloud interface methods.
         """
         logger.info('Writing resources in all regions')
@@ -59,7 +59,7 @@ class CloudWanderer():
 
         Arguments:
             exclude_resources (list):
-                A list of resource names to exclude (e.g. ``['instance']``)
+                exclude_resources (list): A list of service:resources to exclude (e.g. ``['ec2:instance']``)
             concurrency (int):
                 Number of query threads to invoke concurrently.
                 If the number of threads exceeds the number of regions by at least two times
@@ -95,7 +95,7 @@ class CloudWanderer():
 
         Arguments:
             exclude_resources (list):
-                A list of resource names to exclude (e.g. ``['instance']``)
+                exclude_resources (list): A list of service:resources to exclude (e.g. ``['ec2:instance']``)
             region_name (str):
                 The name of the region to get resources from
                 (defaults to session default if not specified)
@@ -123,7 +123,7 @@ class CloudWanderer():
             service_name (str):
                 The name of the service to write resources for (e.g. ``'ec2'``)
             exclude_resources (list):
-                A list of resource names to exclude (e.g. ``['instance']``)
+                exclude_resources (list): A list of service:resources to exclude (e.g. ``['ec2:instance']``)
             region_name (str):
                 The name of the region to get resources from
                 (defaults to session default if not specified)
@@ -135,8 +135,8 @@ class CloudWanderer():
         exclude_resources = exclude_resources or []
 
         for resource_type in self.cloud_interface.get_service_resource_types(service_name=service_name):
-            if resource_type in exclude_resources:
-                logger.info('Skipping %s as per exclude_resources', resource_type)
+            if f'{service_name}:{resource_type}' in exclude_resources:
+                logger.info('Skipping %s as per exclude_resources', f'{service_name}:{resource_type}')
                 continue
             self.write_resources_of_type_in_region(
                 service_name=service_name,

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -102,8 +102,20 @@ class TestCloudWandererWriteResources(unittest.TestCase, GenericAssertionHelpers
                     'Path': re.escape('/')
                 }])
 
-    def test_write_resources_in_region_default_region(self):
+    def test_write_resources_exclude_resources(self):
+        self.wanderer.write_resources(exclude_resources=['ec2:instance'])
 
+        for region_name in self.enabled_regions:
+            self.assert_no_dictionary_overlap(self.storage_connector.read_all(), [{
+                'urn': f'urn:aws:.*:{region_name}:ec2:instance:.*',
+                'attr': 'BaseResource',
+                'VpcId': 'vpc-.*',
+                'SubnetId': 'subnet-.*',
+                'InstanceId': 'i-.*'
+            }])
+        self.assert_dictionary_overlap(self.storage_connector.read_all(), self.us_east_1_resources)
+
+    def test_write_resources_in_region_default_region(self):
         self.wanderer.write_resources_in_region()
 
         self.assert_dictionary_overlap(self.storage_connector.read_all(), self.eu_west_2_resources)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -96,6 +96,8 @@ class TestStorageConnectorReadMixin:
 
 
 class GenericAssertionHelpers:
+    def __init__(self):
+        self.maxDiff = 10000
 
     def assert_dictionary_overlap(self, received, expected):
         """Asserts that every item in expected has an equivalent item in received.
@@ -120,6 +122,7 @@ class GenericAssertionHelpers:
                 matching = []
                 for key, value in expected_item.items():
                     if isinstance(value, str) and isinstance(received_item.get(key), str):
+                        # Allow regex matching of strings (as moto randomly generates resource IDs)
                         matching.append(re.match(value, received_item.get(key)))
                     else:
                         matching.append(received_item.get(key) == value)


### PR DESCRIPTION
- Changed the way `exclude_resources` works so you can differentiate between CloudFormation Stacks and OpsWorks Stacks #70
