### PR TITLE
Ensure complete model attribute list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     converting Boto3 resources to `CloudWandererResources`
     - Removed `write_secondary_attributes` from `BaseStorageConnector` as it's no longer required to be public.
 - Added `name` argument to `get_secondary_attribute` allowing you to get secondary attributes by name.
+- Ensured that all resource attributes that *can* exist *do* exist when `CloudWandererResource` returned from `CloudWandererBoto3Interface`, irrespective of whether they were returned in that particular API call.
 
 ## New Resources
 

--- a/cloudwanderer/__init__.py
+++ b/cloudwanderer/__init__.py
@@ -4,10 +4,12 @@ from . import cloud_wanderer_resource
 from .cloud_wanderer import CloudWanderer
 from .aws_urn import AwsUrn
 from .custom_resource_definitions import CustomResourceDefinitions
+from .boto3_interface import CloudWandererBoto3Interface
 __all__ = [
     'storage_connectors',
     'cloud_wanderer_resource',
     'CloudWanderer',
     'AwsUrn',
-    'CustomResourceDefinitions'
+    'CustomResourceDefinitions',
+    'CloudWandererBoto3Interface'
 ]

--- a/doc_source/_ext/supported_resources.py
+++ b/doc_source/_ext/supported_resources.py
@@ -42,6 +42,7 @@ RESOURCE_TEMPLATE = """
             service="{service_name}",
             resource_type="{resource_name}")
         for resource in resources:
+            resource.load()
             print(resource.urn)
 """
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -22,23 +22,21 @@ class TestFunctional(unittest.TestCase):
                 )
             }
         )
+        self.storage_connector.init()
         self.wanderer = CloudWanderer(storage_connectors=[self.storage_connector])
 
     def test_write_resources(self):
-        self.storage_connector.init()
         self.wanderer.write_resources_concurrently(
-            exclude_resources=['image', 'snapshot', 'policy'],
+            exclude_resources=['ec2:image', 'ec2:snapshot', 'iam:policy'],
             concurrency=128,
             cloud_interface_generator=lambda: CloudWandererBoto3Interface(boto3_session=boto3.session.Session())
         )
 
     def test_write_resources_in_region(self):
-        self.storage_connector.init()
         self.wanderer.write_resources_in_region(
-            region_name='us-east-1', exclude_resources=['image', 'snapshot', 'policy'])
+            region_name='us-east-1', exclude_resources=['ec2:image', 'ec2:snapshot', 'iam:policy'])
 
     def test_write_custom_resource_definition(self):
-        self.storage_connector.init()
         self.wanderer.write_resources_of_service_in_region('lambda', exclude_resources=['images', 'snapshots'])
 
     def test_read_all(self):
@@ -58,3 +56,50 @@ class TestFunctional(unittest.TestCase):
         vpc = list(self.storage_connector.read_resources(service='ec2', resource_type='vpc'))[0]
         print([str(x.urn) for x in self.storage_connector.read_resources(
             service='ec2', resource_type='vpc', account_id=vpc.urn.account_id)])
+
+    def test_documentation_resource_example(self):
+        storage_connector = self.storage_connector
+        resources = storage_connector.read_resources(
+            service="ec2",
+            resource_type="vpc")
+        for resource in resources:
+            resource.load()
+            print(resource.urn)
+            print(resource.cidr_block)
+            print(resource.cidr_block_association_set)
+            print(resource.dhcp_options_id)
+            print(resource.instance_tenancy)
+            print(resource.ipv6_cidr_block_association_set)
+            print(resource.is_default)
+            print(resource.owner_id)
+            print(resource.state)
+            print(resource.tags)
+            print(resource.vpc_id)
+
+    def test_documentation_secondary_attribute_example(self):
+        storage_connector = self.storage_connector
+        resources = storage_connector.read_resources(
+            service="ec2",
+            resource_type="vpc")
+        for resource in resources:
+            resource.get_secondary_attribute(name="vpc_enable_dns_support")
+
+    def test_documentation_subresource_example(self):
+        storage_connector = self.storage_connector
+        resources = storage_connector.read_resources(
+            service="iam",
+            resource_type="role")
+        for resource in resources:
+            resource.load()
+            print(resource.urn)
+            print(resource.arn)
+            print(resource.assume_role_policy_document)
+            print(resource.create_date)
+            print(resource.description)
+            print(resource.max_session_duration)
+            print(resource.path)
+            print(resource.permissions_boundary)
+            print(resource.role_id)
+            print(resource.role_last_used)
+            print(resource.role_name)
+            print(resource.tags)

--- a/tests/integration/boto3_interface/test_boto3_interface.py
+++ b/tests/integration/boto3_interface/test_boto3_interface.py
@@ -1,0 +1,51 @@
+import boto3
+import unittest
+from unittest.mock import ANY
+from cloudwanderer import CloudWandererBoto3Interface
+from ..helpers import get_default_mocker
+
+
+class TestBoto3Interface(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        get_default_mocker().start_general_mock()
+        cls.ec2 = boto3.resource('ec2')
+        cls.vpcs = list(cls.ec2.vpcs.all())
+        cls.boto3_interface = CloudWandererBoto3Interface()
+
+    @classmethod
+    def tearDownClass(cls):
+        get_default_mocker().stop_general_mock()
+
+    def test__get_resource_attributes(self):
+        assert list(self.boto3_interface._get_resource_attributes(self.vpcs[0])) == [
+            'CidrBlock',
+            'DhcpOptionsId',
+            'State',
+            'VpcId',
+            'OwnerId',
+            'InstanceTenancy',
+            'Ipv6CidrBlockAssociationSet',
+            'CidrBlockAssociationSet',
+            'IsDefault',
+            'Tags',
+        ]
+
+    def test__prepare_boto3_resource_data(self):
+        assert self.boto3_interface._prepare_boto3_resource_data(self.vpcs[0]) == {
+            'CidrBlock': '172.31.0.0/16',
+            'CidrBlockAssociationSet': [{
+                'AssociationId': ANY,
+                'CidrBlock': '172.31.0.0/16',
+                'CidrBlockState': {'State': 'associated'}
+            }],
+            'DhcpOptionsId': 'dopt-7a8b9c2d',
+            'InstanceTenancy': 'default',
+            'Ipv6CidrBlockAssociationSet': [],
+            'IsDefault': True,
+            'OwnerId': None,
+            'State': 'available',
+            'Tags': [],
+            'VpcId': ANY,
+        }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -176,7 +176,10 @@ class SetupMocking():
 
     def stop_general_mock(self):
         self.stop_moto_services()
-        self.stop_limit_collections_list()
+        try:
+            self.stop_limit_collections_list()
+        except RuntimeError:
+            pass
 
     def start_moto_services(self, services=None):
         services = self.default_moto_services + (services or [])

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -191,6 +191,7 @@ class SetupMocking():
     def stop_moto_services(self):
         for service in self.service_mocks.values():
             service.stop()
+        self.service_mocks = {}
 
     def start_limit_collections_list(self, restrict_collections):
         """Limit the boto3 resource collections we service to a subset we use for testing."""

--- a/tests/integration/secondary_attributes/test_secondary_attributes.py
+++ b/tests/integration/secondary_attributes/test_secondary_attributes.py
@@ -21,6 +21,7 @@ def generate_params():
                 resource_name,
                 attribute_name
             )
+    get_default_mocker().stop_general_mock()
 
 
 class TestSecondaryAttributes(unittest.TestCase):

--- a/tests/integration/secondary_attributes/test_secondary_attributes.py
+++ b/tests/integration/secondary_attributes/test_secondary_attributes.py
@@ -32,7 +32,7 @@ class TestSecondaryAttributes(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        get_default_mocker().stop_general_mock
+        get_default_mocker().stop_general_mock()
 
     @parameterized.expand(generate_params())
     def test_query_secondary_attributes(self, _, service_name, region_name, resource_type, attribute_name):


### PR DESCRIPTION
To ensure that all expected attributes are always available on CloudWandererResources returned from the storage connector, boto3 now ensures that all keys are present in the raw dictionary by pre-initialising them with a `None` value from the botocore shape of the API call.