### PR TITLE
Parent URNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.14.0
 
+ - Added new DynamoDB secondary index `parent_urn`
+ - Fixed bug where subresources were not cleaned up when `write_resource` was called on `CloudWanderer`
  - Changed `AWSInterface` `get_resources` to expect specific service, resource type, region arguments instead of reusing the arguments from CloudWanderer `write_resources`.
  - Added `get_actions` to `AWSInterface` which returns a list of `GetAndCleanUp` objects which pair `GetAction`s and `CleanUpAction`s.
  - CloudWanderer's `write_resources` now contains the logic for iterating over each `GetAction`, calling `get_resources` on `AWSInterface` and calling `delete_resource_of_type_in_account_region` on each StorageConnector in accordance with the `CleanUpAction`.

--- a/cloudwanderer/aws_interface.py
+++ b/cloudwanderer/aws_interface.py
@@ -74,6 +74,7 @@ class CloudWandererAWSInterface(Boto3CommonAttributesMixin):
         for subresource in resource.get_subresources():
             yield CloudWandererResource(
                 urn=subresource.urn,
+                parent_urn=urn,
                 resource_data=subresource.normalised_raw_data,
                 secondary_attributes=list(subresource.get_secondary_attributes()),
             )

--- a/cloudwanderer/aws_interface.py
+++ b/cloudwanderer/aws_interface.py
@@ -106,6 +106,7 @@ class CloudWandererAWSInterface(Boto3CommonAttributesMixin):
                 for subresource in resource.get_subresources():
                     yield CloudWandererResource(
                         urn=subresource.urn,
+                        parent_urn=resource.urn,
                         resource_data=subresource.normalised_raw_data,
                         secondary_attributes=list(subresource.get_secondary_attributes()),
                     )

--- a/cloudwanderer/cloud_wanderer_resource.py
+++ b/cloudwanderer/cloud_wanderer_resource.py
@@ -44,17 +44,24 @@ class CloudWandererResource:
     """
 
     def __init__(
-        self, urn: URN, resource_data: dict, secondary_attributes: List[dict] = None, loader: Callable = None
+        self,
+        urn: URN,
+        resource_data: dict,
+        secondary_attributes: List[dict] = None,
+        loader: Callable = None,
+        parent_urn: URN = None,
     ) -> None:
         """Initialise the resource.
 
         Arguments:
-            urn (URN): The AWS URN of the resource.
-            resource_data (dict): The dictionary containing the raw data about this resource.
-            secondary_attributes (List[dict]): A list of secondary attribute raw dictionaries.
-            loader (Callable): The method which can be used to fulfil the :meth:`CloudWandererResource.load`.
+            urn: The URN of the resource.
+            parent_urn: The URN of the parent resource (if one exists)
+            resource_data: The dictionary containing the raw data about this resource.
+            secondary_attributes: A list of secondary attribute raw dictionaries.
+            loader: The method which can be used to fulfil the :meth:`CloudWandererResource.load`.
         """
         self.urn = urn
+        self.parent_urn = parent_urn
         self.cloudwanderer_metadata = ResourceMetadata(
             resource_data=resource_data or {}, secondary_attributes=secondary_attributes or []
         )

--- a/cloudwanderer/cloud_wanderer_resource.py
+++ b/cloudwanderer/cloud_wanderer_resource.py
@@ -115,6 +115,7 @@ class CloudWandererResource:
         return str(
             f"{self.__class__.__name__}("
             f"urn={repr(self.urn)}, "
+            f"parent_urn={repr(self.parent_urn)}, "
             f"resource_data={self.cloudwanderer_metadata.resource_data}, "
             f"secondary_attributes={self.cloudwanderer_metadata.secondary_attributes})"
         )

--- a/cloudwanderer/storage_connectors/dynamodb.py
+++ b/cloudwanderer/storage_connectors/dynamodb.py
@@ -254,7 +254,6 @@ class DynamoDbConnector(BaseStorageConnector):
         resource_records += self.dynamodb_table.query(
             IndexName="parent_urn", KeyConditionExpression=Key("_parent_urn").eq(str(urn))
         )["Items"]
-        print(resource_records)
         with self.dynamodb_table.batch_writer() as batch:
             for record in resource_records:
                 logger.debug("Deleting %s", record["_id"])

--- a/cloudwanderer/storage_connectors/dynamodb_schema.json
+++ b/cloudwanderer/storage_connectors/dynamodb_schema.json
@@ -89,7 +89,7 @@
             {
                 "IndexName": "parent_urn",
                 "Projection": {
-                    "ProjectionType": "INCLUDE"
+                    "ProjectionType": "KEYS_ONLY"
                 },
                 "KeySchema": [
                     {

--- a/cloudwanderer/storage_connectors/dynamodb_schema.json
+++ b/cloudwanderer/storage_connectors/dynamodb_schema.json
@@ -1,6 +1,7 @@
 {
     "table": {
-        "AttributeDefinitions": [{
+        "AttributeDefinitions": [
+            {
                 "AttributeName": "_id",
                 "AttributeType": "S"
             },
@@ -23,10 +24,15 @@
             {
                 "AttributeName": "_resource_type_range",
                 "AttributeType": "S"
+            },
+            {
+                "AttributeName": "_parent_urn",
+                "AttributeType": "S"
             }
         ],
         "BillingMode": "PAY_PER_REQUEST",
-        "KeySchema": [{
+        "KeySchema": [
+            {
                 "AttributeName": "_id",
                 "KeyType": "HASH"
             },
@@ -35,7 +41,8 @@
                 "KeyType": "RANGE"
             }
         ],
-        "GlobalSecondaryIndexes": [{
+        "GlobalSecondaryIndexes": [
+            {
                 "IndexName": "resource_type",
                 "Projection": {
                     "ProjectionType": "INCLUDE",
@@ -46,7 +53,8 @@
                         "_service"
                     ]
                 },
-                "KeySchema": [{
+                "KeySchema": [
+                    {
                         "AttributeName": "_resource_type_index",
                         "KeyType": "HASH"
                     },
@@ -67,13 +75,26 @@
                         "_service"
                     ]
                 },
-                "KeySchema": [{
+                "KeySchema": [
+                    {
                         "AttributeName": "_account_id_index",
                         "KeyType": "HASH"
                     },
                     {
                         "AttributeName": "_resource_type",
                         "KeyType": "RANGE"
+                    }
+                ]
+            },
+            {
+                "IndexName": "parent_urn",
+                "Projection": {
+                    "ProjectionType": "INCLUDE"
+                },
+                "KeySchema": [
+                    {
+                        "AttributeName": "_parent_urn",
+                        "KeyType": "HASH"
                     }
                 ]
             }

--- a/cloudwanderer/storage_connectors/memory.py
+++ b/cloudwanderer/storage_connectors/memory.py
@@ -144,7 +144,7 @@ def memory_item_to_resource(urn: URN, items: dict = None, loader: Callable = Non
 
     """
     items = items or {}
-    attributes = [attribute for item_type, attribute in items.items() if item_type != "BaseResource"]
+    attributes = [attribute for item_type, attribute in items.items() if item_type not in ["BaseResource", "ParentUrn"]]
     base_resource = next(iter(resource for item_type, resource in items.items() if item_type == "BaseResource"), {})
     return CloudWandererResource(
         urn=urn,

--- a/cloudwanderer/storage_connectors/memory.py
+++ b/cloudwanderer/storage_connectors/memory.py
@@ -58,12 +58,13 @@ class MemoryStorageConnector(BaseStorageConnector):
         """Return the raw dictionaries stored in memory."""
         for urn_str, items in self._data.items():
             for item_type, item in items.items():
+                item_dict = item if isinstance(item, dict) else {}
                 yield {
                     **{
                         "urn": urn_str,
                         "attr": item_type,
                     },
-                    **item,
+                    **item_dict,
                 }
 
     def write_resource(self, resource: CloudWandererResource) -> None:
@@ -71,6 +72,8 @@ class MemoryStorageConnector(BaseStorageConnector):
         self._data[str(resource.urn)]["BaseResource"] = standardise_data_types(
             resource.cloudwanderer_metadata.resource_data
         )
+        if resource.parent_urn is not None:
+            self._data[str(resource.urn)]["ParentUrn"] = resource.parent_urn
         for secondary_attribute in resource.cloudwanderer_metadata.secondary_attributes:
             self._write_secondary_attribute(
                 urn=resource.urn, attribute_type=secondary_attribute.name, secondary_attribute=secondary_attribute
@@ -95,6 +98,12 @@ class MemoryStorageConnector(BaseStorageConnector):
             del self._data[str(urn)]
         except KeyError:
             pass
+        subresources_to_delete = set()
+        for subresource_urn, resource_dict in self._data.items():
+            if resource_dict.get("ParentUrn") == urn:
+                subresources_to_delete.add(subresource_urn)
+        for subresource_urn in subresources_to_delete:
+            del self._data[subresource_urn]
 
     def delete_resource_of_type_in_account_region(
         self, service: str, resource_type: str, account_id: str, region: str, urns_to_keep: List[URN] = None
@@ -137,4 +146,10 @@ def memory_item_to_resource(urn: URN, items: dict = None, loader: Callable = Non
     items = items or {}
     attributes = [attribute for item_type, attribute in items.items() if item_type != "BaseResource"]
     base_resource = next(iter(resource for item_type, resource in items.items() if item_type == "BaseResource"), {})
-    return CloudWandererResource(urn=urn, resource_data=base_resource, secondary_attributes=attributes, loader=loader)
+    return CloudWandererResource(
+        urn=urn,
+        parent_urn=items.get("ParentUrn"),
+        resource_data=base_resource,
+        secondary_attributes=attributes,
+        loader=loader,
+    )

--- a/cloudwanderer/storage_connectors/memory.py
+++ b/cloudwanderer/storage_connectors/memory.py
@@ -42,10 +42,10 @@ class MemoryStorageConnector(BaseStorageConnector):
             urn = URN.from_string(urn_str)
             if kwargs.get("urn") is not None:
                 if urn == kwargs["urn"]:
-                    yield memory_item_to_resource(urn, loader=self.read_resource)
+                    yield memory_item_to_resource(urn, items, loader=self.read_resource)
                 continue
             if self._urn_matches_kwargs(urn, **kwargs):
-                yield memory_item_to_resource(urn, loader=self.read_resource)
+                yield memory_item_to_resource(urn, items, loader=self.read_resource)
 
     def _urn_matches_kwargs(self, urn: URN, **kwargs) -> bool:
         filter_items = ("account_id", "region", "service", "resource_type")

--- a/doc_source/conf.py
+++ b/doc_source/conf.py
@@ -26,7 +26,7 @@ copyright = "2020, Sam Martin"
 author = "Sam Martin"
 
 # The full version, including alpha/beta/rc tags
-release = "0.13.2"
+release = "0.14.0"
 
 nitpicky = True
 nitpick_ignore = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = re.sub(r"..\s+doctest\s+::", ".. code-block ::", f.read())
 
 setup(
-    version="0.13.2",
+    version="0.14.0",
     python_requires=">=3.6.0",
     name="cloudwanderer",
     packages=find_packages(include=["cloudwanderer", "cloudwanderer.*"]),

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -51,7 +51,7 @@ class TestFunctional(unittest.TestCase):
     def test_write_resources_in_region(self):
         """It is sufficient for this not to throw an exception."""
         self.wanderer.write_resources(
-            regions=["eu-west-1"], exclude_resources=["ec2:image", "ec2:snapshot", "iam:policy"]
+            regions=["us-east-1"], exclude_resources=["ec2:image", "ec2:snapshot", "iam:policy"]
         )
 
     def test_write_custom_resource_definition(self):

--- a/tests/integration/aws_interface/test_boto3_interface_get_resources.py
+++ b/tests/integration/aws_interface/test_boto3_interface_get_resources.py
@@ -37,8 +37,17 @@ class TestCloudWandererGetResources(unittest.TestCase, GenericAssertionHelpers):
         self.assert_dictionary_overlap(result, [{"urn": "urn:aws:.*:eu-west-2:ec2:instance:.*"}])
 
     def test_get_resources_of_type_in_region_us_east_1(self):
-        result = self.aws_interface.get_resources(service_name="ec2", resource_type="instance", region="us-east-1")
-        self.assert_dictionary_overlap(result, [{"urn": "urn:aws:.*:us-east-1:ec2:instance:.*"}])
+        result = self.aws_interface.get_resources(service_name="iam", resource_type="role", region="us-east-1")
+        self.assert_dictionary_overlap(
+            result,
+            [
+                {"urn": "urn:aws:.*:us-east-1:iam:role:test-role"},
+                {
+                    "urn": "urn:aws:.*:us-east-1:iam:role_policy:test-role/test-role-policy",
+                    "parent_urn": "urn:aws:.*:us-east-1:iam:role:test-role",
+                },
+            ],
+        )
 
     def test_get_resources_unsupported_service(self):
         with self.assertRaises(UnsupportedServiceError):

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
@@ -6,28 +6,24 @@ import boto3
 from cloudwanderer import URN, CloudWanderer
 from cloudwanderer.storage_connectors import MemoryStorageConnector
 
-from ..helpers import DEFAULT_SESSION, get_default_mocker
+from ..helpers import DEFAULT_SESSION, GenericAssertionHelpers, get_default_mocker
 from ..mocks import add_infra
 
 
-class TestCloudWandererWriteResource(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.enabled_regions = ["eu-west-2", "us-east-1", "ap-east-1"]
+class TestCloudWandererWriteResource(unittest.TestCase, GenericAssertionHelpers):
+    def setUp(self):
+        self.enabled_regions = ["eu-west-2", "us-east-1", "ap-east-1"]
         mocker = get_default_mocker()
         mocker.start_moto_services(mocker.default_moto_services + ["mock_secretsmanager"])
-        add_infra(regions=cls.enabled_regions)
+        add_infra(regions=self.enabled_regions)
         secretsmanager = boto3.client("secretsmanager")
         secretsmanager.create_secret(Name="test-secret", SecretString="Ssshhh")
-        cls.instances = list(DEFAULT_SESSION.resource("ec2").instances.all())
-
-    @classmethod
-    def tearDownClass(cls):
-        get_default_mocker().stop_general_mock()
-
-    def setUp(self):
+        self.instances = list(DEFAULT_SESSION.resource("ec2").instances.all())
         self.storage_connector = MemoryStorageConnector()
         self.wanderer = CloudWanderer(storage_connectors=[self.storage_connector])
+
+    def tearDown(self) -> None:
+        get_default_mocker().stop_general_mock()
 
     def test_write_valid_ec2_instance(self):
         self.wanderer.write_resource(
@@ -176,3 +172,37 @@ class TestCloudWandererWriteResource(unittest.TestCase):
                 "urn": "urn:aws:123456789012:eu-west-2:secretsmanager:secret:test-secret",
             }
         ]
+
+    def test_cleanup_iam_role(self):
+        role_urn = URN(
+            account_id="123456789012",
+            region="us-east-1",
+            service="iam",
+            resource_type="role",
+            resource_id="test-role",
+        )
+        role_keys = [
+            {"attr": "BaseResource", "urn": "urn:aws:123456789012:us-east-1:iam:role:test-role"},
+            {"attr": "role_inline_policy_attachments", "urn": "urn:aws:123456789012:us-east-1:iam:role:test-role"},
+            {"attr": "role_managed_policy_attachments", "urn": "urn:aws:123456789012:us-east-1:iam:role:test-role"},
+            {
+                "attr": "BaseResource",
+                "urn": "urn:aws:123456789012:us-east-1:iam:role_policy:test-role/test-role-policy",
+            },
+        ]
+
+        # Initial discovery
+        self.wanderer.write_resource(urn=role_urn)
+        self.assert_dictionary_overlap(self.storage_connector.read_all(), role_keys)
+
+        # Delete the role from AWS
+        iam_resource = boto3.resource("iam")
+        iam_resource.Role("test-role").detach_policy(
+            PolicyArn="arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy"
+        )
+        iam_resource.Role("test-role").Policy("test-role-policy").delete()
+        iam_resource.Role("test-role").delete()
+
+        # Delete the role from storage
+        self.wanderer.write_resource(urn=role_urn)
+        self.assert_no_dictionary_overlap(self.storage_connector.read_all(), role_keys)

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
@@ -95,6 +95,7 @@ class TestCloudWandererWriteResource(unittest.TestCase, GenericAssertionHelpers)
                 "attr": "BaseResource",
                 "urn": "urn:aws:123456789012:us-east-1:iam:role_policy:test-role/test-role-policy",
             },
+            {"attr": "ParentUrn", "urn": "urn:aws:123456789012:us-east-1:iam:role_policy:test-role/test-role-policy"},
         ]
 
     def test_write_valid_s3_bucket_eu_west_2(self):

--- a/tests/integration/storage_read_generic.py
+++ b/tests/integration/storage_read_generic.py
@@ -1,9 +1,11 @@
 import logging
 from itertools import combinations
 from time import sleep
+from typing import List
 from unittest.mock import ANY, patch
 
 import cloudwanderer
+from build.lib.cloudwanderer.cloud_wanderer_resource import CloudWandererResource
 from cloudwanderer.cloud_wanderer_resource import SecondaryAttribute
 
 from .helpers import GenericAssertionHelpers, TestStorageConnectorReadMixin, get_default_mocker
@@ -87,7 +89,7 @@ class StorageReadTestMixin(TestStorageConnectorReadMixin, GenericAssertionHelper
 
     def test_account_id(self):
         try:
-            result = list(self.connector.read_resources(account_id="111111111111"))
+            result: List[CloudWandererResource] = list(self.connector.read_resources(account_id="111111111111"))
         except self.valid_exceptions as ex:
             logging.info("Received: %s while testing account_id= but was in valid_exceptions", ex)
             return
@@ -109,7 +111,6 @@ class StorageReadTestMixin(TestStorageConnectorReadMixin, GenericAssertionHelper
                 },
             ],
         )
-
         for account_id in ["111111111111"]:
             self.expected_urns.extend(
                 [
@@ -258,14 +259,14 @@ class StorageReadTestMixin(TestStorageConnectorReadMixin, GenericAssertionHelper
 
     def test_resource_urn(self):
         try:
-            result = list(
+            result: List[CloudWandererResource] = list(
                 self.connector.read_resources(
                     urn=cloudwanderer.URN(
                         account_id="222222222222",
                         region="us-east-1",
                         service="iam",
-                        resource_type="group",
-                        resource_id="test-group",
+                        resource_type="role",
+                        resource_id="test-role",
                     )
                 )
             )
@@ -274,8 +275,18 @@ class StorageReadTestMixin(TestStorageConnectorReadMixin, GenericAssertionHelper
 
         self.assert_secondary_attributes(
             result,
-            {},
-            [],
+            {"role_inline_policy_attachments", "role_managed_policy_attachments"},
+            [
+                {"PolicyNames": ["test-role-policy"], "IsTruncated": False},
+                {
+                    "AttachedPolicies": [
+                        {
+                            "PolicyName": "APIGatewayServiceRolePolicy",
+                            "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
+                        }
+                    ]
+                },
+            ],
         )
 
         for account_id in ["111111111111", "222222222222"]:
@@ -293,8 +304,8 @@ class StorageReadTestMixin(TestStorageConnectorReadMixin, GenericAssertionHelper
                     "account_id": "222222222222",
                     "region": "us-east-1",
                     "service": "iam",
-                    "resource_type": "group",
-                    "resource_id": "test-group",
+                    "resource_type": "role",
+                    "resource_id": "test-role",
                 }
             ]
         )
@@ -304,13 +315,40 @@ class StorageReadTestMixin(TestStorageConnectorReadMixin, GenericAssertionHelper
                     "account_id": "111111111111",
                     "region": "us-east-1",
                     "service": "iam",
-                    "resource_type": "group",
-                    "resource_id": "test-group",
+                    "resource_type": "role",
+                    "resource_id": "test-role",
                 }
             ]
         )
+
+        assert result[0].parent_urn is None
         self.assert_has_matching_urns(result, self.expected_urns)
         self.assert_does_not_have_matching_urns(result, self.not_expected_urns)
+
+    def test_subresource_urn(self):
+        try:
+            result = next(
+                self.connector.read_resources(
+                    urn=cloudwanderer.URN(
+                        account_id="222222222222",
+                        region="us-east-1",
+                        service="iam",
+                        resource_type="role_policy",
+                        resource_id="test-role/test-role-policy",
+                    )
+                ),
+                None,
+            )
+        except self.valid_exceptions:
+            return
+        assert isinstance(result.parent_urn, cloudwanderer.URN)
+        assert result.parent_urn == cloudwanderer.URN(
+            account_id="222222222222",
+            region="us-east-1",
+            service="iam",
+            resource_type="role",
+            resource_id="test-role",
+        )
 
     def test_arg_permutations(self):
         """Try all possible combinations of arguments and compare against the memory storage connector's results."""

--- a/tests/integration/storage_read_generic.py
+++ b/tests/integration/storage_read_generic.py
@@ -5,8 +5,7 @@ from typing import List
 from unittest.mock import ANY, patch
 
 import cloudwanderer
-from build.lib.cloudwanderer.cloud_wanderer_resource import CloudWandererResource
-from cloudwanderer.cloud_wanderer_resource import SecondaryAttribute
+from cloudwanderer.cloud_wanderer_resource import CloudWandererResource, SecondaryAttribute
 
 from .helpers import GenericAssertionHelpers, TestStorageConnectorReadMixin, get_default_mocker
 from .mocks import add_infra, generate_mock_session

--- a/tests/integration/storage_write_generic.py
+++ b/tests/integration/storage_write_generic.py
@@ -1,6 +1,7 @@
-from .mocks import generate_mock_session, add_infra, generate_urn
-from .helpers import get_default_mocker
 from cloudwanderer.cloud_wanderer_resource import CloudWandererResource, SecondaryAttribute
+
+from .helpers import get_default_mocker
+from .mocks import add_infra, generate_mock_session, generate_urn
 
 
 class StorageWriteTestMixin:
@@ -13,27 +14,35 @@ class StorageWriteTestMixin:
         mocker.start_general_mock()
         cls.mock_session = generate_mock_session()
 
-        add_infra(count=100, regions=['eu-west-2'])
+        add_infra(count=100, regions=["eu-west-2"])
         cls.ec2_instances = [
             CloudWandererResource(
-                urn=generate_urn(service='ec2', resource_type='instance', id=instance.instance_id),
-                resource_data=instance.meta.data
+                urn=generate_urn(service="ec2", resource_type="instance", id=instance.instance_id),
+                resource_data=instance.meta.data,
             )
-            for instance in cls.mock_session.resource('ec2').instances.all()
+            for instance in cls.mock_session.resource("ec2").instances.all()
         ]
         cls.vpcs = [
             CloudWandererResource(
-                urn=generate_urn(service='ec2', resource_type='vpc', id=vpc.vpc_id),
+                urn=generate_urn(service="ec2", resource_type="vpc", id=vpc.vpc_id),
                 resource_data=vpc.meta.data,
                 secondary_attributes=[
-                    SecondaryAttribute(
-                        name='EnableDnsSupport',
-                        **{'EnableDnsSupport': {'Value': True}}
-                    )
-                ]
+                    SecondaryAttribute(name="EnableDnsSupport", **{"EnableDnsSupport": {"Value": True}})
+                ],
             )
-            for vpc in cls.mock_session.resource('ec2').vpcs.all()
+            for vpc in cls.mock_session.resource("ec2").vpcs.all()
         ]
+        cls.role = CloudWandererResource(
+            urn=generate_urn(service="iam", resource_type="role", id="test-role"),
+            resource_data={},
+            secondary_attributes=[],
+        )
+        cls.role_policy = CloudWandererResource(
+            urn=generate_urn(service="iam", resource_type="role_policy", id="test-role/test-policy"),
+            parent_urn=cls.role.urn,
+            resource_data={},
+            secondary_attributes=[],
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -41,21 +50,14 @@ class StorageWriteTestMixin:
 
     def test_write_resource_and_attribute(self):
 
-        self.connector.write_resource(
-            resource=self.vpcs[0]
-        )
+        self.connector.write_resource(resource=self.vpcs[0])
         result = self.connector.read_resource(urn=self.vpcs[0].urn)
         assert result.urn == self.vpcs[0].urn
         assert result.is_default is True
-        assert result.cloudwanderer_metadata.secondary_attributes[0][
-            'EnableDnsSupport'] == {
-            'Value': True
-        }
+        assert result.cloudwanderer_metadata.secondary_attributes[0]["EnableDnsSupport"] == {"Value": True}
 
     def test_write_and_delete(self):
-        self.connector.write_resource(
-            resource=self.ec2_instances[0]
-        )
+        self.connector.write_resource(resource=self.ec2_instances[0])
         result_before_delete = self.connector.read_resource(urn=self.ec2_instances[0].urn)
         self.connector.delete_resource(urn=self.ec2_instances[0].urn)
         result_after_delete = self.connector.read_resource(urn=self.ec2_instances[0].urn)
@@ -65,29 +67,39 @@ class StorageWriteTestMixin:
 
     def test_write_and_delete_resource_of_type_in_account_region(self):
         for i in range(5):
-            self.connector.write_resource(
-                resource=self.ec2_instances[i]
-            )
+            self.connector.write_resource(resource=self.ec2_instances[i])
 
         resource_urns = [
-            resource.urn for resource in
-            self.connector.read_resources(
-                service='ec2',
-                resource_type='instance'
-            )
+            resource.urn for resource in self.connector.read_resources(service="ec2", resource_type="instance")
         ]
 
         self.connector.delete_resource_of_type_in_account_region(
-            service='ec2',
-            resource_type='instance',
-            account_id='111111111111',
-            region='eu-west-2',
-            urns_to_keep=resource_urns[4:]
+            service="ec2",
+            resource_type="instance",
+            account_id="111111111111",
+            region="eu-west-2",
+            urns_to_keep=resource_urns[4:],
         )
 
         remaining_urns = [
-            resource.urn for resource in
-            self.connector.read_resources(service='ec2', resource_type='instance')
+            resource.urn for resource in self.connector.read_resources(service="ec2", resource_type="instance")
         ]
 
         assert remaining_urns == resource_urns[4:]
+
+    def test_delete_subresources_from_resource(self):
+        """If we are deleting a parent resource we should delete all its subresources."""
+        self.connector.write_resource(resource=self.role)
+        self.connector.write_resource(resource=self.role_policy)
+        role_before_delete = self.connector.read_resource(urn=self.role.urn)
+        role_policy_before_delete = self.connector.read_resource(urn=self.role_policy.urn)
+
+        # Delete the parent and ensure the subresources are also deleted
+        self.connector.delete_resource(urn=self.role.urn)
+        role_after_delete = self.connector.read_resource(urn=self.role.urn)
+        role_policy_after_delete = self.connector.read_resource(urn=self.role_policy.urn)
+
+        assert role_before_delete.urn == self.role.urn
+        assert role_policy_before_delete.urn == self.role_policy.urn
+        assert role_after_delete is None
+        assert role_policy_after_delete is None

--- a/tests/integration/storage_write_generic.py
+++ b/tests/integration/storage_write_generic.py
@@ -37,8 +37,14 @@ class StorageWriteTestMixin:
             resource_data={},
             secondary_attributes=[],
         )
-        cls.role_policy = CloudWandererResource(
-            urn=generate_urn(service="iam", resource_type="role_policy", id="test-role/test-policy"),
+        cls.role_policy_1 = CloudWandererResource(
+            urn=generate_urn(service="iam", resource_type="role_policy", id="test-role/test-policy-1"),
+            parent_urn=cls.role.urn,
+            resource_data={},
+            secondary_attributes=[],
+        )
+        cls.role_policy_2 = CloudWandererResource(
+            urn=generate_urn(service="iam", resource_type="role_policy", id="test-role/test-policy-2"),
             parent_urn=cls.role.urn,
             resource_data={},
             secondary_attributes=[],
@@ -90,16 +96,21 @@ class StorageWriteTestMixin:
     def test_delete_subresources_from_resource(self):
         """If we are deleting a parent resource we should delete all its subresources."""
         self.connector.write_resource(resource=self.role)
-        self.connector.write_resource(resource=self.role_policy)
+        self.connector.write_resource(resource=self.role_policy_1)
+        self.connector.write_resource(resource=self.role_policy_2)
         role_before_delete = self.connector.read_resource(urn=self.role.urn)
-        role_policy_before_delete = self.connector.read_resource(urn=self.role_policy.urn)
+        role_policy_1_before_delete = self.connector.read_resource(urn=self.role_policy_1.urn)
+        role_policy_2_before_delete = self.connector.read_resource(urn=self.role_policy_2.urn)
 
         # Delete the parent and ensure the subresources are also deleted
         self.connector.delete_resource(urn=self.role.urn)
         role_after_delete = self.connector.read_resource(urn=self.role.urn)
-        role_policy_after_delete = self.connector.read_resource(urn=self.role_policy.urn)
+        role_policy_1_after_delete = self.connector.read_resource(urn=self.role_policy_1.urn)
+        role_policy_2_after_delete = self.connector.read_resource(urn=self.role_policy_2.urn)
 
         assert role_before_delete.urn == self.role.urn
-        assert role_policy_before_delete.urn == self.role_policy.urn
+        assert role_policy_1_before_delete.urn == self.role_policy_1.urn
+        assert role_policy_2_before_delete.urn == self.role_policy_2.urn
         assert role_after_delete is None
-        assert role_policy_after_delete is None
+        assert role_policy_1_after_delete is None
+        assert role_policy_2_after_delete is None

--- a/tests/unit/test_cloudwanderer_resource.py
+++ b/tests/unit/test_cloudwanderer_resource.py
@@ -68,6 +68,7 @@ class TestCloudWandererResource(unittest.TestCase):
             "CloudWandererResource("
             "urn=URN(account_id='111111111111', region='eu-west-2', service='ec2', "
             "resource_type='vpc', resource_id='vpc-11111111'), "
+            "parent_urn=None, "
             "resource_data={'CidrBlock': '10.0.0.0/0'}, secondary_attributes=[{'EnableDnsSupport': {'Value': True}}]"
             ")"
         )
@@ -83,6 +84,7 @@ class TestCloudWandererResource(unittest.TestCase):
             "CloudWandererResource("
             "urn=URN(account_id='111111111111', region='eu-west-2', service='ec2', "
             "resource_type='vpc', resource_id='vpc-11111111'), "
+            "parent_urn=None, "
             "resource_data={'CidrBlock': '10.0.0.0/0'}, secondary_attributes=[{'EnableDnsSupport': {'Value': True}}]"
             ")"
         )

--- a/tests/unit/test_cloudwanderer_resource.py
+++ b/tests/unit/test_cloudwanderer_resource.py
@@ -98,3 +98,10 @@ class TestCloudWandererResource(unittest.TestCase):
             resource_data=None,
             secondary_attributes=[],
         )
+
+    def test_subresource(self):
+        parent_urn = URN.from_string("urn:aws:111111111111:us-east-1:iam:role:test-role")
+        urn = URN.from_string("urn:aws:111111111111:us-east-1:iam:role_policy:test-role/test-policy")
+        cwr = CloudWandererResource(urn=urn, parent_urn=parent_urn, resource_data={}, secondary_attributes=[])
+
+        assert cwr.parent_urn == parent_urn


### PR DESCRIPTION
- Added new DynamoDB secondary index `parent_urn`
- Fixed bug where subresources were not cleaned up when `write_resource` was called on `CloudWanderer` (fixes #104 )