### PR TITLE
0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.21.0
+# 0.20.2
+
+- Fixed bug causing secondary attributes to be fetched twice.
+# 0.20.1
 
 - Fixed nonfunctional `read_all` method on `GremlinStorageConnector`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.20.2
 
 - Fixed bug causing secondary attributes to be fetched twice.
+- Added relationship between roles and managed policies
+- Fixed secondary attribute of role policy attachments
+
 # 0.20.1
 
 - Fixed nonfunctional `read_all` method on `GremlinStorageConnector`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 - Fixed bug causing secondary attributes to be fetched twice.
 - Added relationship between roles and managed policies
-- Fixed secondary attribute of role policy attachments
+- Removed secondary attribute of inline role policy attachments
+- Fixed secondary attribute of managed role policy attachments
+- Added tests for IAM roles
 
 # 0.20.1
 

--- a/cloudwanderer/aws_interface/exceptions.py
+++ b/cloudwanderer/aws_interface/exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions pertaining to the AWS Interface."""
+
+
+class SecondaryAttributesNotFetchedError(Exception):
+    """Secondary attributes have not yet been fetched for this resource. Call fetch_secondary_attributes first."""

--- a/cloudwanderer/aws_interface/interface.py
+++ b/cloudwanderer/aws_interface/interface.py
@@ -78,6 +78,7 @@ class CloudWandererAWSInterface:
                 raise UnsupportedResourceTypeError(f"Resource type {urn.resource_type} doesn't support get_resource()")
             logger.info("Loading resource data.")
             resource.load()
+            resource.fetch_secondary_attributes()
 
         except botocore.exceptions.ClientError as ex:
             error_code = ex.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
@@ -103,6 +104,7 @@ class CloudWandererAWSInterface:
                     resource.get_urn().resource_id,
                 )
                 for dependent_resource in resource.collection(resource_type=dependent_resource_type):
+                    dependent_resource.fetch_secondary_attributes()
                     logger.debug("Found %s", dependent_resource)
                     if not dependent_resource.meta.data and hasattr(dependent_resource, "load"):
                         dependent_resource.load()
@@ -146,6 +148,7 @@ class CloudWandererAWSInterface:
 
         try:
             for resource in service.collection(resource_type=resource_type, filters=resource_map.default_filters):
+                resource.fetch_secondary_attributes()
                 dependent_resource_urns = []
                 for dependent_resource_type in resource.dependent_resource_types:
                     logger.info(
@@ -156,6 +159,7 @@ class CloudWandererAWSInterface:
                         resource.get_urn().resource_id,
                     )
                     for dependent_resource in resource.collection(resource_type=dependent_resource_type):
+                        dependent_resource.fetch_secondary_attributes()
                         logger.debug("Found %s", dependent_resource)
                         if not dependent_resource.meta.data and hasattr(dependent_resource, "load"):
                             dependent_resource.load()

--- a/cloudwanderer/aws_interface/interface.py
+++ b/cloudwanderer/aws_interface/interface.py
@@ -110,16 +110,13 @@ class CloudWandererAWSInterface:
                     dependent_resource_urns.append(urn)
                     yield CloudWandererResource(
                         urn=urn,
-                        resource_data={
-                            **dependent_resource.normalized_raw_data,
-                            **dependent_resource.get_secondary_attributes_map(),
-                        },
+                        resource_data=dependent_resource.normalized_raw_data,
                         parent_urn=resource.get_urn(),
                         relationships=dependent_resource.relationships,
                     )
         yield CloudWandererResource(
             urn=resource.get_urn(),
-            resource_data={**resource.normalized_raw_data, **resource.get_secondary_attributes_map()},
+            resource_data=resource.normalized_raw_data,
             dependent_resource_urns=dependent_resource_urns,
             relationships=resource.relationships,
         )
@@ -166,16 +163,13 @@ class CloudWandererAWSInterface:
                         dependent_resource_urns.append(urn)
                         yield CloudWandererResource(
                             urn=urn,
-                            resource_data={
-                                **dependent_resource.normalized_raw_data,
-                                **dependent_resource.get_secondary_attributes_map(),
-                            },
+                            resource_data=dependent_resource.normalized_raw_data,
                             parent_urn=resource.get_urn(),
                             relationships=dependent_resource.relationships,
                         )
                 yield CloudWandererResource(
                     urn=resource.get_urn(),
-                    resource_data={**resource.normalized_raw_data, **resource.get_secondary_attributes_map()},
+                    resource_data=resource.normalized_raw_data,
                     dependent_resource_urns=dependent_resource_urns,
                     relationships=resource.relationships,
                 )

--- a/cloudwanderer/aws_interface/resource_definitions/iam/2010-05-08/resources-1.json
+++ b/cloudwanderer/aws_interface/resource_definitions/iam/2010-05-08/resources-1.json
@@ -563,19 +563,6 @@
         "path": "Role"
       },
       "has": {
-        "RoleInlinePolicyAttachments": {
-          "resource": {
-            "type": "RoleInlinePolicyAttachments",
-            "identifiers": [
-              {
-                "target": "Name",
-                "source": "identifier",
-                "name": "RoleName"
-              }
-            ],
-            "path": "@"
-          }
-        },
         "RoleManagedPolicyAttachments": {
           "resource": {
             "type": "RoleManagedPolicyAttachments",

--- a/cloudwanderer/aws_interface/resource_definitions/iam/2010-05-08/resources-cw-1.json
+++ b/cloudwanderer/aws_interface/resource_definitions/iam/2010-05-08/resources-cw-1.json
@@ -59,15 +59,6 @@
         }
       ]
     },
-    "RoleInlinePolicyAttachments": {
-      "type": "secondaryAttribute",
-      "secondaryAttributeMaps": [
-        {
-          "sourcePath": "PolicyNames",
-          "destinationName": "InlinePolicyAttachments"
-        }
-      ]
-    },
     "RoleManagedPolicyAttachments": {
       "type": "secondaryAttribute",
       "secondaryAttributeMaps": [

--- a/cloudwanderer/aws_interface/resource_definitions/iam/2010-05-08/resources-cw-1.json
+++ b/cloudwanderer/aws_interface/resource_definitions/iam/2010-05-08/resources-cw-1.json
@@ -41,13 +41,29 @@
     },
     "Role": {
       "type": "resource",
-      "regionalResource": false
+      "regionalResource": false,
+      "relationships": [
+        {
+          "basePath": "ManagedPolicyAttachments[]",
+          "idParts": [
+            {
+              "path": "PolicyArn",
+              "regexPattern": "[^:]+:[^:]+:[^:]+::(?P<account_id>[^:]*):policy.*/(?P<id_part_0>[^:]+)"
+            }
+          ],
+          "service": "iam",
+          "resourceType": "policy",
+          "regionSource": "sameAsResource",
+          "accountIdSource": "unknown",
+          "direction": "outbound"
+        }
+      ]
     },
     "RoleInlinePolicyAttachments": {
       "type": "secondaryAttribute",
       "secondaryAttributeMaps": [
         {
-          "sourcePath": "@",
+          "sourcePath": "PolicyNames",
           "destinationName": "InlinePolicyAttachments"
         }
       ]
@@ -56,7 +72,7 @@
       "type": "secondaryAttribute",
       "secondaryAttributeMaps": [
         {
-          "sourcePath": "@",
+          "sourcePath": "AttachedPolicies",
           "destinationName": "ManagedPolicyAttachments"
         }
       ]

--- a/cloudwanderer/aws_interface/resource_factory.py
+++ b/cloudwanderer/aws_interface/resource_factory.py
@@ -1,7 +1,7 @@
 """Create the CloudWandererServiceResource objects that do the magic."""
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
 
 import jmespath  # type: ignore
 from boto3.resources.base import ServiceResource
@@ -19,6 +19,7 @@ from ..urn import URN, PartialUrn
 from ..utils import snake_to_pascal
 from .boto3_helpers import _clean_boto3_metadata
 from .boto3_loaders import MergedServiceLoader, ServiceMap
+from .exceptions import SecondaryAttributesNotFetchedError
 
 if TYPE_CHECKING:
     from .session import CloudWandererBoto3Session
@@ -75,7 +76,7 @@ class CloudWandererResourceFactory(ResourceFactory):
             # This should only exist only exist on Resources, not on Services
             attrs["get_discovery_action_templates"] = self._create_get_discovery_action_templates()
             # attrs["get_dependent_resource"] = self._create_get_dependent_resource(service_context)
-            attrs["get_secondary_attributes_map"] = self._create_get_secondary_attributes_map()
+            attrs["secondary_attributes_map"] = self._create_secondary_attributes_map()
             if hasattr(original_class_definition, "load"):
                 attrs["load"] = self._create_load(original_class_definition=original_class_definition)
         else:
@@ -86,7 +87,7 @@ class CloudWandererResourceFactory(ResourceFactory):
         attrs["get_account_id"] = self._create_get_account_id()
         attrs["get_urn"] = self._create_get_urn()
         attrs["get_region"] = self._create_get_region()
-        attrs["get_secondary_attributes"] = self._create_get_secondary_attributes()
+        attrs["fetch_secondary_attributes"] = self._create_fetch_secondary_attributes()
 
     def _create_load(self, original_class_definition: Any) -> Callable:
         if not hasattr(original_class_definition, "load"):
@@ -105,7 +106,7 @@ class CloudWandererResourceFactory(ResourceFactory):
                     f"{self.service_name} {self.resource_type} does not have a load definition in its resources-1.json"
                 )
 
-            has_non_empty_values = any(list([x for x in identifiers.values()]))
+            has_non_empty_values = any(x for x in identifiers.values())
             if not has_non_empty_values:
                 logger.debug(
                     "Load is a noop on this %s %s because we are an empty_resource=True resource",
@@ -244,11 +245,20 @@ class CloudWandererResourceFactory(ResourceFactory):
 
         return get_urn
 
-    def _create_get_secondary_attributes_map(self) -> Callable[..., Dict[str, Any]]:
-        def get_secondary_attributes_map(self) -> Dict[str, Any]:
-            """Return a dictionary representation of this resource's secondary attributes."""
+    def _create_secondary_attributes_map(self) -> property:
+        def secondary_attributes_map(self) -> Dict[str, Any]:
+            """Return a dictionary representation of this resource's secondary attributes.
+
+            Raises:
+                SecondaryAttributesNotFetchedError: When the secondary attributes haven't been fetched yet.
+            """
+            if not self._secondary_attributes_fetched:
+                raise SecondaryAttributesNotFetchedError(
+                    "Secondary attributes have not yet been fetched for this "
+                    "resource. Call fetch_secondary_attributes first."
+                )
             result = {}
-            for secondary_attribute in self.get_secondary_attributes():
+            for secondary_attribute in self._secondary_attributes:
                 logger.debug("Getting secondary attribute: %s", secondary_attribute)
                 for attribute_map in secondary_attribute.resource_map.secondary_attribute_maps:
                     result[attribute_map.destination_name] = jmespath.search(
@@ -256,10 +266,12 @@ class CloudWandererResourceFactory(ResourceFactory):
                     )
             return result
 
-        return get_secondary_attributes_map
+        return property(secondary_attributes_map)
 
-    def _create_get_secondary_attributes(self) -> Callable:
-        def get_secondary_attributes(self) -> Generator["CloudWandererServiceResource", None, None]:
+    def _create_fetch_secondary_attributes(self) -> Callable:
+        def fetch_secondary_attributes(self) -> None:
+            self._secondary_attributes = []
+
             for secondary_attribute_name in self.secondary_attribute_names:
                 logger.info(
                     "Getting %s secondary attributes from %s for %s",
@@ -270,9 +282,11 @@ class CloudWandererResourceFactory(ResourceFactory):
                 getter = getattr(self, snake_to_pascal(secondary_attribute_name))
                 secondary_attribute_resource = getter()
                 secondary_attribute_resource.load()
-                yield secondary_attribute_resource
+                secondary_attribute_resource.fetch_secondary_attributes()
+                self._secondary_attributes.append(secondary_attribute_resource)
+            self._secondary_attributes_fetched = True
 
-        return get_secondary_attributes
+        return fetch_secondary_attributes
 
     def _create_secondary_attribute_names(self) -> property:
         def secondary_attribute_names(self) -> List[str]:
@@ -314,7 +328,7 @@ class CloudWandererResourceFactory(ResourceFactory):
             """Return the raw data dictionary for this resource, ensuring that all possible keys are present."""
             result = {attribute: None for attribute in self.shape.members.keys()}
             result.update(self.meta.data or {})
-            result.update(self.get_secondary_attributes_map())
+            result.update(self.secondary_attributes_map)
             return _clean_boto3_metadata(result)
 
         return property(normalized_raw_data)
@@ -442,3 +456,4 @@ class CloudWandererResourceFactory(ResourceFactory):
             attrs["shape"] = self._create_shape()
             attrs["relationships"] = self._create_relationships()
             attrs["is_dependent_resource"] = self._create_is_dependent_resource()
+            attrs["_secondary_attributes_fetched"] = False

--- a/cloudwanderer/aws_interface/resource_factory.py
+++ b/cloudwanderer/aws_interface/resource_factory.py
@@ -259,7 +259,6 @@ class CloudWandererResourceFactory(ResourceFactory):
                 )
             result = {}
             for secondary_attribute in self._secondary_attributes:
-                logger.debug("Getting secondary attribute: %s", secondary_attribute)
                 for attribute_map in secondary_attribute.resource_map.secondary_attribute_maps:
                     result[attribute_map.destination_name] = jmespath.search(
                         attribute_map.source_path, secondary_attribute.normalized_raw_data

--- a/doc_source/decisions/iam_role_policies.rst
+++ b/doc_source/decisions/iam_role_policies.rst
@@ -1,0 +1,24 @@
+IAM Role Policies
+===================
+
+IAM Role policies come in two varieties:
+
+1. Inline Policies
+2. Managed Policies
+
+The former is a dependent resource (because to list inline policies you must supply the ``RoleName`` to the ``ListRolePolicies`` function).
+The latter is a top-level resource (i.e. it can be discovered without supplying any arguments to the ``ListPolicies`` function) but discovering the relationship
+between the Role and the Managed Policies attached to it requires a call to the ``ListAttachedRolePolicies`` function.
+
+This is why the ``resources-1.json`` and ``resources-cw-1.json`` seem so asymmetric by having:
+
+1. ``RoleManagedPolicyAttachments`` (a secondary attribute)
+2. ``RolePolicy`` (a dependent resource)
+3. ``Policy`` (a base resource)
+
+The order of operations when discovering roles and their policies is as follows:
+
+1. List roles
+2. Fetch each role's secondary attributes (``RoleManagedPolicyAttachments``)
+3. Create a ``Relationship`` on the ``Role`` with each ``RoleManagedPolicyAttachment``
+4. Fetch each role's dependent resources (``RolePolicy``)

--- a/doc_source/examples.rst
+++ b/doc_source/examples.rst
@@ -200,8 +200,6 @@ Next we need to find out what policies are attached, we can either do this with 
 .. doctest ::
 
     >>> role.inline_policy_attachments
-    {'PolicyNames': ['test-role-policy'], 'IsTruncated': False, 'Marker': None}
-    >>> role.inline_policy_attachments['PolicyNames']
     ['test-role-policy']
 
 Or we can do it with the :attr:`~cloudwanderer.cloud_wanderer_resource.CloudWandererResource.dependent_resource_urns` property.

--- a/doc_source/examples.rst
+++ b/doc_source/examples.rst
@@ -188,21 +188,14 @@ can therefore be retrieved from the API without specifying the VPC of which it i
 How do I list Subresources?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Let's say we want to get a list of role policies. We can start by getting the role
+Let's say we want to get a list of inline role policies. We can start by getting the role
 
 .. doctest ::
 
     >>> role = next(storage_connector.read_resources(service='iam', resource_type='role'))
     >>> role.load()
 
-Next we need to find out what policies are attached, we can either do this with the secondary attributes.
-
-.. doctest ::
-
-    >>> role.inline_policy_attachments
-    ['test-role-policy']
-
-Or we can do it with the :attr:`~cloudwanderer.cloud_wanderer_resource.CloudWandererResource.dependent_resource_urns` property.
+Next we need to find out what inline policies are attached, as inline policies are dependent resources, we need to first find out what dependent resource URNs there are.
 
 .. doctest ::
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = re.sub(r"..\s+doctest\s+::", ".. code-block ::", f.read())
 
 setup(
-    version="0.20.1",
+    version="0.20.2",
     python_requires=">=3.6.0",
     name="cloudwanderer",
     packages=find_packages(include=["cloudwanderer", "cloudwanderer.*"]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from moto import mock_ec2, mock_iam
+from moto import mock_iam
 
 from cloudwanderer import CloudWanderer
 from cloudwanderer.aws_interface import CloudWandererAWSInterface, CloudWandererBoto3Session
@@ -53,17 +53,6 @@ def single_iam_role(iam_service):
     with mock_iam():
         create_iam_role()
         return list(iam_service.collection("role").all())[0]
-
-
-@pytest.fixture
-def single_ec2_vpc(ec2_service):
-    """Return a single Ec2 Vpc.
-
-    Be warned, you can ONLY access properties on the resultant vpc that do not entail additional API calls.
-    See single_iam_role for more details on how to mock additional API calls.
-    """
-    with mock_ec2():
-        return list(ec2_service.collection("vpc").all())[0]
 
 
 @pytest.fixture

--- a/tests/functional/end_to_end/test_functional_gremlin.py
+++ b/tests/functional/end_to_end/test_functional_gremlin.py
@@ -41,12 +41,12 @@ def test_a_write_resources_concurrently(cloudwanderer):
 
 def test_write_resources_in_region(cloudwanderer):
     """It is sufficient for this not to throw an exception."""
-    cloudwanderer.write_resources(regions=["eu-west-1"], exclude_resources=[])
+    cloudwanderer.write_resources(regions=["us-east-1"], exclude_resources=[])
 
 
 def test_write_resource_type(cloudwanderer):
     """It is sufficient for this not to throw an exception."""
-    cloudwanderer.write_resources(regions=["us-east-1"], service_resource_types=[ServiceResourceType("ec2", "vpc")])
+    cloudwanderer.write_resources(regions=["us-east-1"], service_resource_types=[ServiceResourceType("iam", "role")])
 
 
 def test_read_all(storage_connector):

--- a/tests/integration/aws_interface/test_service_resource_resource.py
+++ b/tests/integration/aws_interface/test_service_resource_resource.py
@@ -143,17 +143,13 @@ def test_secondary_attribute_maps(iam_service):
     create_iam_role()
     single_iam_role = list(iam_service.collection("role").all())[0]
     assert single_iam_role.get_secondary_attributes_map() == {
-        "InlinePolicyAttachments": {"PolicyNames": ["test-role-policy"], "IsTruncated": False, "Marker": None},
-        "ManagedPolicyAttachments": {
-            "AttachedPolicies": [
-                {
-                    "PolicyName": "APIGatewayServiceRolePolicy",
-                    "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
-                }
-            ],
-            "IsTruncated": False,
-            "Marker": None,
-        },
+        "InlinePolicyAttachments": ["test-role-policy"],
+        "ManagedPolicyAttachments": [
+            {
+                "PolicyName": "APIGatewayServiceRolePolicy",
+                "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
+            }
+        ],
     }
 
 

--- a/tests/integration/aws_interface/test_service_resource_resource.py
+++ b/tests/integration/aws_interface/test_service_resource_resource.py
@@ -10,6 +10,7 @@ from ...pytest_helpers import compare_dict_allow_any, create_iam_role, create_s3
 
 
 @mock_ec2
+@mock_sts
 def test_raw_data(ec2_service):
     compare_dict_allow_any(
         {
@@ -64,16 +65,19 @@ def test_normalized_raw_data(ec2_service):
 
 
 @mock_ec2
+@mock_sts
 def test_resource_type(ec2_service):
     assert get_single_ec2_vpc(ec2_service).resource_type == "vpc"
 
 
 @mock_ec2
+@mock_sts
 def test_get_region_regional_resources(ec2_service):
     assert get_single_ec2_vpc(ec2_service).get_region() == "eu-west-2"
 
 
 @mock_s3
+@mock_sts
 def test_get_region_global_service_global_resources(s3_service):
     create_s3_buckets(regions=["us-east-1", "eu-west-2", "ap-east-1"])
 
@@ -89,11 +93,13 @@ def test_get_account_id(ec2_service):
 
 
 @mock_ec2
+@mock_sts
 def test_service_name(ec2_service):
     assert get_single_ec2_vpc(ec2_service).service_name == "ec2"
 
 
 @mock_ec2
+@mock_sts
 def test_resource_map(ec2_service):
     assert isinstance(get_single_ec2_vpc(ec2_service).resource_map, ResourceMap)
 
@@ -118,6 +124,7 @@ def test_collection(iam_service):
     single_iam_role = list(iam_service.collection("role").all())[0]
     single_role_policy = list(single_iam_role.collection("role_policy").all())[0]
     single_role_policy.load()
+    single_role_policy.fetch_secondary_attributes()
 
     assert (
         str(single_role_policy.get_urn()) == "urn:aws:123456789012:us-east-1:iam:role_policy:test-role/test-role-policy"
@@ -133,6 +140,7 @@ def test_collection(iam_service):
 
 
 @mock_ec2
+@mock_sts
 def test_secondary_attribute_names(ec2_service):
     assert get_single_ec2_vpc(ec2_service).secondary_attribute_names == ["vpc_enable_dns_support"]
 
@@ -142,7 +150,8 @@ def test_secondary_attribute_names(ec2_service):
 def test_secondary_attribute_maps(iam_service):
     create_iam_role()
     single_iam_role = list(iam_service.collection("role").all())[0]
-    assert single_iam_role.get_secondary_attributes_map() == {
+    single_iam_role.fetch_secondary_attributes()
+    assert single_iam_role.secondary_attributes_map == {
         "InlinePolicyAttachments": ["test-role-policy"],
         "ManagedPolicyAttachments": [
             {
@@ -154,6 +163,7 @@ def test_secondary_attribute_maps(iam_service):
 
 
 @mock_ec2
+@mock_sts
 def test_shape(ec2_service):
     assert get_single_ec2_vpc(ec2_service).shape.name == "Vpc"
 

--- a/tests/integration/aws_interface/test_service_resource_resource.py
+++ b/tests/integration/aws_interface/test_service_resource_resource.py
@@ -152,7 +152,6 @@ def test_secondary_attribute_maps(iam_service):
     single_iam_role = list(iam_service.collection("role").all())[0]
     single_iam_role.fetch_secondary_attributes()
     assert single_iam_role.secondary_attributes_map == {
-        "InlinePolicyAttachments": ["test-role-policy"],
         "ManagedPolicyAttachments": [
             {
                 "PolicyName": "APIGatewayServiceRolePolicy",

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
@@ -76,7 +76,6 @@ def test_write_valid_iam_role(cloudwanderer_aws):
             "AssumeRolePolicyDocument": {},
             "CreateDate": ANY,
             "Description": None,
-            "InlinePolicyAttachments": ["test-role-policy"],
             "ManagedPolicyAttachments": [
                 {
                     "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
@@ -264,7 +263,6 @@ def test_cleanup_iam_role(cloudwanderer_aws):
             "AssumeRolePolicyDocument": {},
             "CreateDate": ANY,
             "Description": None,
-            "InlinePolicyAttachments": ["test-role-policy"],
             "ManagedPolicyAttachments": [
                 {
                     "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resource.py
@@ -76,17 +76,13 @@ def test_write_valid_iam_role(cloudwanderer_aws):
             "AssumeRolePolicyDocument": {},
             "CreateDate": ANY,
             "Description": None,
-            "InlinePolicyAttachments": {"IsTruncated": False, "Marker": None, "PolicyNames": ["test-role-policy"]},
-            "ManagedPolicyAttachments": {
-                "AttachedPolicies": [
-                    {
-                        "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
-                        "PolicyName": "APIGatewayServiceRolePolicy",
-                    }
-                ],
-                "IsTruncated": False,
-                "Marker": None,
-            },
+            "InlinePolicyAttachments": ["test-role-policy"],
+            "ManagedPolicyAttachments": [
+                {
+                    "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
+                    "PolicyName": "APIGatewayServiceRolePolicy",
+                }
+            ],
             "MaxSessionDuration": 3600,
             "Path": "/",
             "PermissionsBoundary": None,
@@ -268,17 +264,13 @@ def test_cleanup_iam_role(cloudwanderer_aws):
             "AssumeRolePolicyDocument": {},
             "CreateDate": ANY,
             "Description": None,
-            "InlinePolicyAttachments": {"IsTruncated": False, "Marker": None, "PolicyNames": ["test-role-policy"]},
-            "ManagedPolicyAttachments": {
-                "AttachedPolicies": [
-                    {
-                        "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
-                        "PolicyName": "APIGatewayServiceRolePolicy",
-                    }
-                ],
-                "IsTruncated": False,
-                "Marker": None,
-            },
+            "InlinePolicyAttachments": ["test-role-policy"],
+            "ManagedPolicyAttachments": [
+                {
+                    "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
+                    "PolicyName": "APIGatewayServiceRolePolicy",
+                }
+            ],
             "MaxSessionDuration": 3600,
             "Path": "/",
             "PermissionsBoundary": None,

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -225,17 +225,13 @@ def test_cleanup_resources_of_type_us_east_1(cloudwanderer_aws):
                 "AssumeRolePolicyDocument": {},
                 "CreateDate": ANY,
                 "Description": None,
-                "InlinePolicyAttachments": {"IsTruncated": False, "Marker": None, "PolicyNames": ["test-role-policy"]},
-                "ManagedPolicyAttachments": {
-                    "AttachedPolicies": [
-                        {
-                            "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
-                            "PolicyName": "APIGatewayServiceRolePolicy",
-                        }
-                    ],
-                    "IsTruncated": False,
-                    "Marker": None,
-                },
+                "InlinePolicyAttachments": ["test-role-policy"],
+                "ManagedPolicyAttachments": [
+                    {
+                        "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",
+                        "PolicyName": "APIGatewayServiceRolePolicy",
+                    }
+                ],
                 "MaxSessionDuration": ANY,
                 "Path": "/",
                 "PermissionsBoundary": None,

--- a/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
+++ b/tests/integration/cloudwanderer/test_cloud_wanderer_write_resources.py
@@ -225,7 +225,6 @@ def test_cleanup_resources_of_type_us_east_1(cloudwanderer_aws):
                 "AssumeRolePolicyDocument": {},
                 "CreateDate": ANY,
                 "Description": None,
-                "InlinePolicyAttachments": ["test-role-policy"],
                 "ManagedPolicyAttachments": [
                     {
                         "PolicyArn": "arn:aws:iam::aws:policy/aws-service-role/APIGatewayServiceRolePolicy",

--- a/tests/integration/custom_resources/iam/role_multiple_resources.json
+++ b/tests/integration/custom_resources/iam/role_multiple_resources.json
@@ -1,0 +1,260 @@
+{
+    "service": "iam",
+    "mockData": {
+        "get_paginator.side_effect": [
+            {
+                "paginate.return_value": [
+                    {
+                        "Roles": [
+                            {
+                                "Path": "/",
+                                "RoleName": "TestRole",
+                                "RoleId": "111111111111111111111",
+                                "Arn": "arn:aws:iam::0123456789012:role/service-role/TestRole",
+                                "CreateDate": "2021-10-16T10:02:10Z",
+                                "AssumeRolePolicyDocument": {
+                                    "Version": "2012-10-17",
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Principal": {
+                                                "Service": "sagemaker.amazonaws.com"
+                                            },
+                                            "Action": "sts:AssumeRole"
+                                        }
+                                    ]
+                                },
+                                "Description": "SageMaker Test Role.",
+                                "MaxSessionDuration": 3600
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "paginate.return_value": [
+                    {
+                        "PolicyNames": [
+                            "TestRolePolicy"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "get_role_policy.return_value": {
+            "RoleName": "TestRole",
+            "PolicyName": "TestRolePolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents"
+                        ],
+                        "Resource": "arn:aws:logs:eu-west-1:*:*",
+                        "Effect": "Allow"
+                    }
+                ]
+            }
+        },
+        "list_attached_role_policies.return_value": {
+            "AttachedPolicies": [
+                {
+                    "PolicyName": "TestManagedRole",
+                    "PolicyArn": "arn:aws:iam::01234567890:policy/TestManagedRole"
+                }
+            ]
+        }
+    },
+    "getResources": {
+        "serviceName": "iam",
+        "resourceType": "role",
+        "region": "us-east-1"
+    },
+    "expectedCalls": {
+        "get_role_policy": [
+            {
+                "args": [],
+                "kwargs": {
+                    "RoleName": "TestRole",
+                    "PolicyName": "TestRolePolicy"
+                }
+            }
+        ],
+        "list_attached_role_policies": [
+            {
+                "args": [],
+                "kwargs": {
+                    "RoleName": "TestRole"
+                }
+            }
+        ]
+    },
+    "expectedResults": [
+        {
+            "urn": {
+                "cloud_name": "aws",
+                "account_id": {},
+                "region": "us-east-1",
+                "service": "iam",
+                "resource_type": "role_policy",
+                "resource_id_parts": [
+                    "TestRole",
+                    "TestRolePolicy"
+                ],
+                "resource_id": "TestRole/TestRolePolicy"
+            },
+            "relationships": [],
+            "dependent_resource_urns": [],
+            "parent_urn": {
+                "cloud_name": "aws",
+                "account_id": {},
+                "region": "us-east-1",
+                "service": "iam",
+                "resource_type": "role",
+                "resource_id_parts": [
+                    "TestRole"
+                ],
+                "resource_id": "TestRole"
+            },
+            "cloudwanderer_metadata": {
+                "RoleName": "TestRole",
+                "PolicyName": "TestRolePolicy",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": [
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
+                            ],
+                            "Resource": "arn:aws:logs:eu-west-1:*:*",
+                            "Effect": "Allow"
+                        }
+                    ]
+                }
+            },
+            "role_name": "TestRole",
+            "policy_name": "TestRolePolicy",
+            "policy_document": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents"
+                        ],
+                        "Resource": "arn:aws:logs:eu-west-1:*:*",
+                        "Effect": "Allow"
+                    }
+                ]
+            }
+        },
+        {
+            "urn": {
+                "cloud_name": "aws",
+                "account_id": {},
+                "region": "us-east-1",
+                "service": "iam",
+                "resource_type": "role",
+                "resource_id_parts": [
+                    "TestRole"
+                ],
+                "resource_id": "TestRole"
+            },
+            "relationships": [
+                [
+                    {
+                        "cloud_name": "aws",
+                        "account_id": "01234567890",
+                        "region": "us-east-1",
+                        "service": "iam",
+                        "resource_type": "policy",
+                        "resource_id_parts": [
+                            "TestManagedRole"
+                        ],
+                        "resource_id": "TestManagedRole"
+                    },
+                    "RelationshipDirection.OUTBOUND"
+                ]
+            ],
+            "dependent_resource_urns": [
+                {
+                    "cloud_name": "aws",
+                    "account_id": {},
+                    "region": "us-east-1",
+                    "service": "iam",
+                    "resource_type": "role_policy",
+                    "resource_id_parts": [
+                        "TestRole",
+                        "TestRolePolicy"
+                    ],
+                    "resource_id": "TestRole/TestRolePolicy"
+                }
+            ],
+            "parent_urn": null,
+            "cloudwanderer_metadata": {
+                "Path": "/",
+                "RoleName": "TestRole",
+                "RoleId": "111111111111111111111",
+                "Arn": "arn:aws:iam::0123456789012:role/service-role/TestRole",
+                "CreateDate": "2021-10-16T10:02:10Z",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "sagemaker.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Description": "SageMaker Test Role.",
+                "MaxSessionDuration": 3600,
+                "PermissionsBoundary": null,
+                "Tags": null,
+                "RoleLastUsed": null,
+                "ManagedPolicyAttachments": [
+                    {
+                        "PolicyName": "TestManagedRole",
+                        "PolicyArn": "arn:aws:iam::01234567890:policy/TestManagedRole"
+                    }
+                ]
+            },
+            "path": "/",
+            "role_name": "TestRole",
+            "role_id": "111111111111111111111",
+            "arn": "arn:aws:iam::0123456789012:role/service-role/TestRole",
+            "create_date": "2021-10-16T10:02:10Z",
+            "assume_role_policy_document": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": "sagemaker.amazonaws.com"
+                        },
+                        "Action": "sts:AssumeRole"
+                    }
+                ]
+            },
+            "description": "SageMaker Test Role.",
+            "max_session_duration": 3600,
+            "permissions_boundary": null,
+            "tags": null,
+            "role_last_used": null,
+            "managed_policy_attachments": [
+                {
+                    "PolicyName": "TestManagedRole",
+                    "PolicyArn": "arn:aws:iam::01234567890:policy/TestManagedRole"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration/custom_resources/iam/role_single_resource.json
+++ b/tests/integration/custom_resources/iam/role_single_resource.json
@@ -1,0 +1,256 @@
+{
+    "service": "iam",
+    "mockData": {
+        "get_role.return_value": {
+            "Role": {
+                "Path": "/",
+                "RoleName": "TestRole",
+                "RoleId": "111111111111111111111",
+                "Arn": "arn:aws:iam::0123456789012:role/service-role/TestRole",
+                "CreateDate": "2021-10-16T10:02:10Z",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "sagemaker.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Description": "SageMaker Test Role.",
+                "MaxSessionDuration": 3600
+            }
+        },
+        "get_paginator.return_value.paginate.return_value": [
+            {
+                "PolicyNames": [
+                    "TestRolePolicy"
+                ]
+            }
+        ],
+        "get_role_policy.return_value": {
+            "RoleName": "TestRole",
+            "PolicyName": "TestRolePolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents"
+                        ],
+                        "Resource": "arn:aws:logs:eu-west-1:*:*",
+                        "Effect": "Allow"
+                    }
+                ]
+            }
+        },
+        "list_attached_role_policies.return_value": {
+            "AttachedPolicies": [
+                {
+                    "PolicyName": "TestManagedRole",
+                    "PolicyArn": "arn:aws:iam::01234567890:policy/TestManagedRole"
+                }
+            ]
+        }
+    },
+    "getResource": {
+        "urn": "urn:aws:123456789012:us-east-1:iam:role:TestRole"
+    },
+    "expectedCalls": {
+        "get_role": [
+            {
+                "args": [],
+                "kwargs": {
+                    "RoleName": "TestRole"
+                }
+            }
+        ],
+        "get_role_policy": [
+            {
+                "args": [],
+                "kwargs": {
+                    "RoleName": "TestRole",
+                    "PolicyName": "TestRolePolicy"
+                }
+            }
+        ],
+        "list_attached_role_policies": [
+            {
+                "args": [],
+                "kwargs": {
+                    "RoleName": "TestRole"
+                }
+            }
+        ]
+    },
+    "expectedResults": [
+        {
+            "urn": {
+                "cloud_name": "aws",
+                "account_id": {},
+                "region": "us-east-1",
+                "service": "iam",
+                "resource_type": "role_policy",
+                "resource_id_parts": [
+                    "TestRole",
+                    "TestRolePolicy"
+                ],
+                "resource_id": "TestRole/TestRolePolicy"
+            },
+            "relationships": [],
+            "dependent_resource_urns": [],
+            "parent_urn": {
+                "cloud_name": "aws",
+                "account_id": {},
+                "region": "us-east-1",
+                "service": "iam",
+                "resource_type": "role",
+                "resource_id_parts": [
+                    "TestRole"
+                ],
+                "resource_id": "TestRole"
+            },
+            "cloudwanderer_metadata": {
+                "RoleName": "TestRole",
+                "PolicyName": "TestRolePolicy",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": [
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
+                            ],
+                            "Resource": "arn:aws:logs:eu-west-1:*:*",
+                            "Effect": "Allow"
+                        }
+                    ]
+                }
+            },
+            "role_name": "TestRole",
+            "policy_name": "TestRolePolicy",
+            "policy_document": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents"
+                        ],
+                        "Resource": "arn:aws:logs:eu-west-1:*:*",
+                        "Effect": "Allow"
+                    }
+                ]
+            }
+        },
+        {
+            "urn": {
+                "cloud_name": "aws",
+                "account_id": {},
+                "region": "us-east-1",
+                "service": "iam",
+                "resource_type": "role",
+                "resource_id_parts": [
+                    "TestRole"
+                ],
+                "resource_id": "TestRole"
+            },
+            "relationships": [
+                [
+                    {
+                        "cloud_name": "aws",
+                        "account_id": "01234567890",
+                        "region": "us-east-1",
+                        "service": "iam",
+                        "resource_type": "policy",
+                        "resource_id_parts": [
+                            "TestManagedRole"
+                        ],
+                        "resource_id": "TestManagedRole"
+                    },
+                    "RelationshipDirection.OUTBOUND"
+                ]
+            ],
+            "dependent_resource_urns": [
+                {
+                    "cloud_name": "aws",
+                    "account_id": {},
+                    "region": "us-east-1",
+                    "service": "iam",
+                    "resource_type": "role_policy",
+                    "resource_id_parts": [
+                        "TestRole",
+                        "TestRolePolicy"
+                    ],
+                    "resource_id": "TestRole/TestRolePolicy"
+                }
+            ],
+            "parent_urn": null,
+            "cloudwanderer_metadata": {
+                "Path": "/",
+                "RoleName": "TestRole",
+                "RoleId": "111111111111111111111",
+                "Arn": "arn:aws:iam::0123456789012:role/service-role/TestRole",
+                "CreateDate": "2021-10-16T10:02:10Z",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "sagemaker.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Description": "SageMaker Test Role.",
+                "MaxSessionDuration": 3600,
+                "PermissionsBoundary": null,
+                "Tags": null,
+                "RoleLastUsed": null,
+                "ManagedPolicyAttachments": [
+                    {
+                        "PolicyName": "TestManagedRole",
+                        "PolicyArn": "arn:aws:iam::01234567890:policy/TestManagedRole"
+                    }
+                ]
+            },
+            "path": "/",
+            "role_name": "TestRole",
+            "role_id": "111111111111111111111",
+            "arn": "arn:aws:iam::0123456789012:role/service-role/TestRole",
+            "create_date": "2021-10-16T10:02:10Z",
+            "assume_role_policy_document": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": "sagemaker.amazonaws.com"
+                        },
+                        "Action": "sts:AssumeRole"
+                    }
+                ]
+            },
+            "description": "SageMaker Test Role.",
+            "max_session_duration": 3600,
+            "permissions_boundary": null,
+            "tags": null,
+            "role_last_used": null,
+            "managed_policy_attachments": [
+                {
+                    "PolicyName": "TestManagedRole",
+                    "PolicyArn": "arn:aws:iam::01234567890:policy/TestManagedRole"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -194,3 +194,13 @@ def inferred_ec2_vpcs(cloudwanderer_boto3_session):
         )
         for vpc in cloudwanderer_boto3_session.resource("ec2").vpcs.all()
     ]
+
+
+def get_single_ec2_vpc(ec2_service):
+    """Return a single Ec2 Vpc.
+
+    Be warned, you can ONLY access properties on the resultant vpc that do not entail additional API calls.
+    See single_iam_role for more details on how to mock additional API calls.
+    """
+
+    return list(ec2_service.collection("vpc").all())[0]

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -202,5 +202,6 @@ def get_single_ec2_vpc(ec2_service):
     Be warned, you can ONLY access properties on the resultant vpc that do not entail additional API calls.
     See single_iam_role for more details on how to mock additional API calls.
     """
-
-    return list(ec2_service.collection("vpc").all())[0]
+    vpc = list(ec2_service.collection("vpc").all())[0]
+    vpc.fetch_secondary_attributes()
+    return vpc


### PR DESCRIPTION
- Fixed bug causing secondary attributes to be fetched twice.
- Added relationship between roles and managed policies
- Removed secondary attribute of inline role policy attachments
- Fixed secondary attribute of managed role policy attachments
- Added tests for IAM roles