### PR TITLE
Allow the setting of account_id and enabled_regions in CloudWandererA…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.26.0
 
-- Allow the setting of `account_id` and `enabled_regions` in `CloudWandererAWSInterface` if you already know these values and want to avoid unecessary API calls.
+- Allow the setting of `account_id` and `enabled_regions` in `CloudWandererAWSInterface` if you already know these values and want to avoid unnecessary API calls.
+- Added the option of passing a `CloudWandererBoto3SessionGetterClientConfig` for configuring internal getter clients in `CloudWandererBoto3Session`.
 # 0.25.2
 
 - Fix #242 by moving to using `MANIFEST.in`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.26.0
+
+- Allow the setting of `account_id` and `enabled_regions` in `CloudWandererAWSInterface` if you already know these values and want to avoid unecessary API calls.
 # 0.25.2
 
 - Fix #242 by moving to using `MANIFEST.in`

--- a/cloudwanderer/aws_interface/__init__.py
+++ b/cloudwanderer/aws_interface/__init__.py
@@ -1,6 +1,11 @@
 """The CloudWanderer AWS Interface."""
 from .interface import CloudWandererAWSInterface
-from .session import CloudWandererBoto3Session
 from .models import AWSResourceTypeFilter
+from .session import CloudWandererBoto3Session, CloudWandererBoto3SessionGetterClientConfig
 
-__all__ = ["CloudWandererAWSInterface", "CloudWandererBoto3Session", "AWSResourceTypeFilter"]
+__all__ = [
+    "CloudWandererAWSInterface",
+    "CloudWandererBoto3Session",
+    "AWSResourceTypeFilter",
+    "CloudWandererBoto3SessionGetterClientConfig",
+]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = re.sub(r"..\s+doctest\s+::", ".. code-block ::", f.read())
 
 setup(
-    version="0.25.2",
+    version="0.26.0",
     python_requires=">=3.6.0",
     name="cloudwanderer",
     packages=find_packages(include=["cloudwanderer", "cloudwanderer.*"]),

--- a/tests/unit/aws_interface/test_aws_interface.py
+++ b/tests/unit/aws_interface/test_aws_interface.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+from cloudwanderer.aws_interface import CloudWandererAWSInterface
+
+
+def test_get_account_id():
+    subject = CloudWandererAWSInterface(
+        cloudwanderer_boto3_session=MagicMock(**{"get_account_id.return_value": "0123456789012"})
+    )
+
+    assert subject.get_account_id() == "0123456789012"
+
+
+def test_get_account_id_init_arg():
+    subject = CloudWandererAWSInterface(account_id="0123456789012")
+
+    assert subject.get_account_id() == "0123456789012"
+
+
+def test_get_enabled_regions():
+    subject = CloudWandererAWSInterface(
+        cloudwanderer_boto3_session=MagicMock(**{"get_enabled_regions.return_value": ["eu-west-1"]})
+    )
+
+    assert subject.get_enabled_regions() == ["eu-west-1"]
+
+
+def test_get_enabled_regions_init_arg():
+    subject = CloudWandererAWSInterface(enabled_regions=["eu-west-1"])
+
+    assert subject.get_enabled_regions() == ["eu-west-1"]

--- a/tests/unit/aws_interface/test_cloudwanderer_boto3_session.py
+++ b/tests/unit/aws_interface/test_cloudwanderer_boto3_session.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+from cloudwanderer.aws_interface import CloudWandererBoto3Session, CloudWandererBoto3SessionGetterClientConfig
+
+
+def test_get_account_id():
+    botocore_session = MagicMock()
+    subject = CloudWandererBoto3Session(
+        aws_access_key_id="A",
+        aws_secret_access_key="A",
+        aws_session_token="A",
+        botocore_session=botocore_session,
+        getter_client_config=CloudWandererBoto3SessionGetterClientConfig(
+            sts={"endpoint_url": "sts.eu-west-1.amazonaws.com"}
+        ),
+    )
+
+    subject.get_account_id()
+
+    botocore_session.create_client.assert_called_with(
+        "sts",
+        region_name=None,
+        api_version=None,
+        use_ssl=True,
+        verify=None,
+        endpoint_url="sts.eu-west-1.amazonaws.com",
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        aws_session_token=None,
+        config=None,
+    )
+
+
+def test_get_enabled_regions():
+    botocore_session = MagicMock()
+    subject = CloudWandererBoto3Session(
+        aws_access_key_id="A",
+        aws_secret_access_key="A",
+        aws_session_token="A",
+        botocore_session=botocore_session,
+        getter_client_config=CloudWandererBoto3SessionGetterClientConfig(
+            ec2={"endpoint_url": "ec2.eu-west-1.amazonaws.com"}
+        ),
+    )
+
+    subject.get_enabled_regions()
+
+    botocore_session.create_client.assert_called_with(
+        "ec2",
+        region_name=None,
+        api_version=None,
+        use_ssl=True,
+        verify=None,
+        endpoint_url="ec2.eu-west-1.amazonaws.com",
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        aws_session_token=None,
+        config=None,
+    )


### PR DESCRIPTION
…WSInterface if you already know these values and want to avoid unecessary API calls
Fixes #245 