### PR TITLE
fix MANIFEST.in to include py.typed in pypi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include cloudwanderer/** *.pyi
 recursive-include cloudwanderer/** *.json
-include ./cloudwanderer/py.typed
+include cloudwanderer/py.typed


### PR DESCRIPTION
Apparently adding "./" in front of a file path in MANIFEST.in prevents the file from being included in the package...
Tested by building locally, installing from the local wheel and verifying that `py.typed` file is included in the installed files.