### PR TITLE
Allow Custom Resource Definitions to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.29.0
+
+- Fix bug where wafv2 `RegionalWebAcl` resources would not correctly load their data
+
 # 0.28.0
 
 - Added `cloudName` to RelationshipSpecification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.29.0
 
-- Fix bug where wafv2 `RegionalWebAcl` resources would not correctly load their data
+- Fix bug where wafv2 `RegionalWebAcl` resources would not correctly load their data (Fixes [#250](https://github.com/CloudWanderer-io/CloudWanderer/issues/250))
+- Made it possible to pass a custom `CustomServiceLoader` into `ServiceLoader`
+- Made it possible to pass an entirely custom (not just relative) path into `CustomServiceLoader` (fixes [#249](https://github.com/CloudWanderer-io/CloudWanderer/issues/249))
 
 # 0.28.0
 

--- a/cloudwanderer/aws_interface/boto3_loaders.py
+++ b/cloudwanderer/aws_interface/boto3_loaders.py
@@ -93,7 +93,7 @@ class MergedServiceLoader(Loader):
     def list_available_services(self, type_name: str = "resources-1") -> List[str]:
         _ = type_name
         """Return a list of service names that can be loaded."""
-        return list(set(self.cloudwanderer_available_services + self.boto3_available_services))
+        return sorted(list(set(self.cloudwanderer_available_services + self.boto3_available_services)))
 
     def determine_latest_version(self, service_name: str, type_name: str) -> str:
         return max(self.list_api_versions(service_name, type_name))

--- a/cloudwanderer/aws_interface/boto3_loaders.py
+++ b/cloudwanderer/aws_interface/boto3_loaders.py
@@ -27,7 +27,13 @@ logger = logging.getLogger(__name__)
 
 
 class CustomServiceLoader:
-    """A class to load custom services."""
+    """A class to load custom services.
+
+    Parameters:
+        definition_path:
+            The absolute path to the resource definition JSON folders. This must mirror the folder structure
+            and JSON schema found in CloudWanderer/boto3.
+    """
 
     def __init__(self, definition_path: str = None) -> None:
 

--- a/cloudwanderer/aws_interface/boto3_loaders.py
+++ b/cloudwanderer/aws_interface/boto3_loaders.py
@@ -29,8 +29,11 @@ logger = logging.getLogger(__name__)
 class CustomServiceLoader:
     """A class to load custom services."""
 
-    def __init__(self, definition_path: str = "resource_definitions") -> None:
-        self.service_definitions_path = os.path.join(pathlib.Path(__file__).parent.absolute(), definition_path)
+    def __init__(self, definition_path: str = None) -> None:
+
+        self.service_definitions_path = definition_path or os.path.join(
+            pathlib.Path(__file__).parent.absolute(), "resource_definitions"
+        )
 
     @memoized_method()
     def get_service_definition(self, service_name: str, type_name: str, api_version: str) -> dict:
@@ -72,9 +75,11 @@ class CustomServiceLoader:
 class MergedServiceLoader(Loader):
     """A class to merge the services from a custom service loader with those of Boto3."""
 
-    def __init__(self) -> None:
-        self.custom_service_loader = CustomServiceLoader()
-        botocore_session = botocore.session.get_session()
+    def __init__(
+        self, custom_service_loader: CustomServiceLoader = None, botocore_session: botocore.session.Session = None
+    ) -> None:
+        self.custom_service_loader = custom_service_loader or CustomServiceLoader()
+        botocore_session = botocore_session or botocore.session.get_session()
         self.botocore_loader = botocore_session.get_component("data_loader")
         boto3_data_path = os.path.join(os.path.dirname(boto3.__file__), "data")
         self.botocore_loader.search_paths.append(boto3_data_path)

--- a/cloudwanderer/aws_interface/resource_definitions/wafv2/2019-07-29/resources-cw-1.json
+++ b/cloudwanderer/aws_interface/resource_definitions/wafv2/2019-07-29/resources-cw-1.json
@@ -3,7 +3,7 @@
     "resources": {
         "RegionalWebAcl": {
             "type": "resource",
-            "requiresLoadForFullMetadata": true
+            "requiresLoad": true
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = re.sub(r"..\s+doctest\s+::", ".. code-block ::", f.read())
 
 setup(
-    version="0.28.0",
+    version="0.29.0",
     python_requires=">=3.6.0",
     name="cloudwanderer",
     packages=find_packages(include=["cloudwanderer", "cloudwanderer.*"]),

--- a/tests/integration/custom_resources/wafv2/regional_web_acl_multiple_resources.json
+++ b/tests/integration/custom_resources/wafv2/regional_web_acl_multiple_resources.json
@@ -1,19 +1,36 @@
 {
     "service": "wafv2",
     "mockData": {
-        "get_paginator.return_value.paginate.return_value": [
-            {
-                "WebACLs": [
-                    {
-                        "Name": "test-webacl",
-                        "Id": "11111111-1111-1111-1111-111111111111",
-                        "Description": "Test Web ACL",
-                        "LockToken": "11111111-1111-1111-1111-111111111111",
-                        "ARN": "arn:aws:wafv2:eu-west-1:123456789012:regional/webacl/test-webacl/11111111-1111-1111-1111-111111111111"
-                    }
-                ]
-            }
-        ]
+        "get_paginator.return_value.paginate.return_value": [{
+            "WebACLs": [{
+                "Name": "test-webacl",
+                "Id": "11111111-1111-1111-1111-111111111111",
+                "Description": "Test Web ACL",
+                "LockToken": "11111111-1111-1111-1111-111111111111",
+                "ARN": "arn:aws:wafv2:eu-west-1:123456789012:regional/webacl/test-webacl/11111111-1111-1111-1111-111111111111"
+            }]
+        }],
+        "get_web_acl.return_value": {
+            "WebACL": {
+                "Name": "testwebacl",
+                "Id": "1111111b-1111-1111-1111-111111111111",
+                "ARN": "arn:aws:wafv2:eu-west-2:0123456789012:regional/webacl/testwebacl/0e638f5b-abcb-4897-97de-995e9080c936",
+                "DefaultAction": {
+                    "Allow": {}
+                },
+                "Description": "TestDescription",
+                "Rules": [],
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": true,
+                    "CloudWatchMetricsEnabled": true,
+                    "MetricName": "testwebacl"
+                },
+                "Capacity": 0,
+                "ManagedByFirewallManager": false,
+                "LabelNamespace": "awswaf:0123456789012:webacl:testwebacl:"
+            },
+            "LockToken": "1111111b-1111-1111-1111-111111111111"
+        }
     },
     "getResources": {
         "serviceName": "wafv2",
@@ -21,55 +38,70 @@
         "region": "eu-west-2"
     },
     "expectedCalls": {
-        "describe_secret": []
-    },
-    "expectedResults": [
-        {
-            "urn": {
-                "cloud_name": "aws",
-                "account_id": "0123456789012",
-                "region": "eu-west-2",
-                "service": "wafv2",
-                "resource_type": "regional_web_acl",
-                "resource_id_parts": [
-                    "test-webacl",
-                    "11111111-1111-1111-1111-111111111111"
-                ],
-                "resource_id": "test-webacl/11111111-1111-1111-1111-111111111111"
-            },
-            "relationships": [],
-            "dependent_resource_urns": [],
-            "parent_urn": null,
-            "cloudwanderer_metadata": {
+        "get_web_acl": [{
+            "args": [],
+            "kwargs": {
                 "Name": "test-webacl",
                 "Id": "11111111-1111-1111-1111-111111111111",
-                "ARN": "arn:aws:wafv2:eu-west-1:123456789012:regional/webacl/test-webacl/11111111-1111-1111-1111-111111111111",
-                "DefaultAction": null,
-                "Description": "Test Web ACL",
-                "Rules": null,
-                "VisibilityConfig": null,
-                "Capacity": null,
-                "PreProcessFirewallManagerRuleGroups": null,
-                "PostProcessFirewallManagerRuleGroups": null,
-                "ManagedByFirewallManager": null,
-                "LabelNamespace": null,
-                "CustomResponseBodies": null,
-                "LockToken": "11111111-1111-1111-1111-111111111111"
+                "Scope": "REGIONAL"
+            }
+        }]
+    },
+    "expectedResults": [{
+        "urn": {
+            "cloud_name": "aws",
+            "account_id": "0123456789012",
+            "region": "eu-west-2",
+            "service": "wafv2",
+            "resource_type": "regional_web_acl",
+            "resource_id_parts": [
+                "test-webacl",
+                "11111111-1111-1111-1111-111111111111"
+            ],
+            "resource_id": "test-webacl/11111111-1111-1111-1111-111111111111"
+        },
+        "relationships": [],
+        "dependent_resource_urns": [],
+        "parent_urn": null,
+        "cloudwanderer_metadata": {
+            "Name": "testwebacl",
+            "Id": "1111111b-1111-1111-1111-111111111111",
+            "ARN": "arn:aws:wafv2:eu-west-2:0123456789012:regional/webacl/testwebacl/0e638f5b-abcb-4897-97de-995e9080c936",
+            "DefaultAction": {
+                "Allow": {}
             },
-            "name": "test-webacl",
-            "id": "11111111-1111-1111-1111-111111111111",
-            "arn": "arn:aws:wafv2:eu-west-1:123456789012:regional/webacl/test-webacl/11111111-1111-1111-1111-111111111111",
-            "default_action": null,
-            "description": "Test Web ACL",
-            "rules": null,
-            "visibility_config": null,
-            "capacity": null,
-            "pre_process_firewall_manager_rule_groups": null,
-            "post_process_firewall_manager_rule_groups": null,
-            "managed_by_firewall_manager": null,
-            "label_namespace": null,
-            "custom_response_bodies": null,
-            "lock_token": "11111111-1111-1111-1111-111111111111"
-        }
-    ]
+            "Description": "TestDescription",
+            "Rules": [],
+            "VisibilityConfig": {
+                "SampledRequestsEnabled": true,
+                "CloudWatchMetricsEnabled": true,
+                "MetricName": "testwebacl"
+            },
+            "Capacity": 0,
+            "PreProcessFirewallManagerRuleGroups": null,
+            "PostProcessFirewallManagerRuleGroups": null,
+            "ManagedByFirewallManager": false,
+            "LabelNamespace": "awswaf:0123456789012:webacl:testwebacl:",
+            "CustomResponseBodies": null
+        },
+        "name": "testwebacl",
+        "id": "1111111b-1111-1111-1111-111111111111",
+        "arn": "arn:aws:wafv2:eu-west-2:0123456789012:regional/webacl/testwebacl/0e638f5b-abcb-4897-97de-995e9080c936",
+        "default_action": {
+            "Allow": {}
+        },
+        "description": "TestDescription",
+        "rules": [],
+        "visibility_config": {
+            "SampledRequestsEnabled": true,
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "testwebacl"
+        },
+        "capacity": 0,
+        "pre_process_firewall_manager_rule_groups": null,
+        "post_process_firewall_manager_rule_groups": null,
+        "managed_by_firewall_manager": false,
+        "label_namespace": "awswaf:0123456789012:webacl:testwebacl:",
+        "custom_response_bodies": null
+    }]
 }

--- a/tests/unit/aws_interface/test_boto3_loaders.py
+++ b/tests/unit/aws_interface/test_boto3_loaders.py
@@ -11,7 +11,7 @@ def test_merged_service_loader_list_available_services():
         custom_service_loader=mock_custom_service_loader, botocore_session=mock_botocore_session
     )
 
-    assert subject.list_available_services() == ["lambda", "ec2"]
+    assert subject.list_available_services() == ["ec2", "lambda"]
 
 
 def test_custom_service_loader_path_default():

--- a/tests/unit/aws_interface/test_boto3_loaders.py
+++ b/tests/unit/aws_interface/test_boto3_loaders.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+from cloudwanderer.aws_interface.boto3_loaders import CustomServiceLoader, MergedServiceLoader
+
+
+def test_merged_service_loader_list_available_services():
+    mock_custom_service_loader = MagicMock(available_services=["lambda"])
+    mock_botocore_session = MagicMock(**{"get_component.return_value.list_available_services.return_value": ["ec2"]})
+
+    subject = MergedServiceLoader(
+        custom_service_loader=mock_custom_service_loader, botocore_session=mock_botocore_session
+    )
+
+    assert subject.list_available_services() == ["lambda", "ec2"]
+
+
+def test_custom_service_loader_path_default():
+    subject = CustomServiceLoader()
+
+    assert subject.service_definitions_path.endswith("cloudwanderer/aws_interface/resource_definitions")
+
+
+def test_custom_service_loader_path_custom():
+    subject = CustomServiceLoader(definition_path="testpath")
+
+    assert subject.service_definitions_path == "testpath"


### PR DESCRIPTION
- Fix bug where wafv2 `RegionalWebAcl` resources would not correctly load their data (Fixes [#250](https://github.com/CloudWanderer-io/CloudWanderer/issues/250))
- Made it possible to pass a custom `CustomServiceLoader` into `ServiceLoader`
- Made it possible to pass an entirely custom (not just relative) path into `CustomServiceLoader` (fixes [#249](https://github.com/CloudWanderer-io/CloudWanderer/issues/249))